### PR TITLE
Don't deselect axis when a modifier key is pressed

### DIFF
--- a/dfetch.yaml
+++ b/dfetch.yaml
@@ -15,6 +15,7 @@ manifest:
     dst: libraries/qcustomplot
     branch: v2.1.1
     repo-path: jgeudens/qcustomplot-release
+    patch: libraries/patches/axis_deselect_modifier.patch
 
   - name: googletest
     dst: tests/googletest

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -11,6 +11,7 @@ The latest *ModbusScope* installer or standalone version can always be downloade
 ### Fixed
 
 - Fixed warning when loading mbs file with unsupported datalevel
+- Don't deselect axis when Ctrl key is pressed ([Github #304](https://github.com/jgeudens/ModbusScope/issues/304))
 
 ### Changed
 

--- a/libraries/patches/axis_deselect_modifier.patch
+++ b/libraries/patches/axis_deselect_modifier.patch
@@ -1,0 +1,19 @@
+diff --git a/qcustomplot.cpp b/qcustomplot.cpp
+index 72b5bfb8..398c28df 100644
+--- a/qcustomplot.cpp
++++ b/qcustomplot.cpp
+@@ -15660,7 +15660,13 @@ void QCustomPlot::mouseReleaseEvent(QMouseEvent *event)
+   {
+     if (mSelectionRect && mSelectionRect->isActive()) // a simple click shouldn't successfully finish a selection rect, so cancel it here
+       mSelectionRect->cancel();
+-    if (event->button() == Qt::LeftButton)
++
++    /* CHANGE for ModbusScope
++     * Don't process click event when modifier is pressed (except for multi select)
++     */
++    bool modifier = event->modifiers() & (~mMultiSelectModifier);
++
++    if (event->button() == Qt::LeftButton && !modifier)
+       processPointSelection(event);
+     
+     // emit specialized click signals of QCustomPlot instance:

--- a/libraries/qcustomplot/.dfetch_data.yaml
+++ b/libraries/qcustomplot/.dfetch_data.yaml
@@ -2,9 +2,9 @@
 # For more info see https://dfetch.rtfd.io/en/latest/getting_started.html
 dfetch:
   branch: v2.1.1
-  hash: d3eb46e886543ee270971502ab26f23f
-  last_fetch: 10/11/2022, 21:28:01
-  patch: ''
+  hash: 6ab47fb31d9b5225d77d202a0abfb71a
+  last_fetch: 12/01/2024, 17:22:40
+  patch: libraries/patches/axis_deselect_modifier.patch
   remote_url: https://github.com/jgeudens/qcustomplot-release
   revision: d8cca69ccd94e6bce6e9047105a9e452ff0a6cc5
   tag: ''

--- a/libraries/qcustomplot/qcustomplot.cpp
+++ b/libraries/qcustomplot/qcustomplot.cpp
@@ -15660,7 +15660,13 @@ void QCustomPlot::mouseReleaseEvent(QMouseEvent *event)
   {
     if (mSelectionRect && mSelectionRect->isActive()) // a simple click shouldn't successfully finish a selection rect, so cancel it here
       mSelectionRect->cancel();
-    if (event->button() == Qt::LeftButton)
+
+    /* CHANGE for ModbusScope
+     * Don't process click event when modifier is pressed (except for multi select)
+     */
+    bool modifier = event->modifiers() & (~mMultiSelectModifier);
+
+    if (event->button() == Qt::LeftButton && !modifier)
       processPointSelection(event);
     
     // emit specialized click signals of QCustomPlot instance:

--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -37,6 +37,13 @@ GraphView::GraphView(GuiModel * pGuiModel, SettingsModel *pSettingsModel, GraphD
     * */
     _pPlot->setPlottingHints(QCP::phCacheLabels | QCP::phFastPolylines);
 
+    /*
+    * Use other modifier key than Ctrl for multi select.
+    * ModbusScope uses Ctrl for adding/moving marker.
+    * Note: Multi select is disabled, but modifier needs to be changed from default.
+    * */
+    _pPlot->setMultiSelectModifier(Qt::ShiftModifier);
+
     // Samples are enabled
     _bEnableSampleHighlight = true;
 


### PR DESCRIPTION
Fix for #304 

This fix also required a change in the QCustomplot library.