### PR TITLE
Move mbc import to mainwindow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The latest *ModbusScope* installer or standalone version can always be downloade
 
 ### Changed
 
-- xx
+- Various improvements to importing MBC registers ([Github #344](https://github.com/ModbusScope/ModbusScope/issues/344))
 
 ### Removed
 

--- a/src/dialogs/importmbcdialog.cpp
+++ b/src/dialogs/importmbcdialog.cpp
@@ -2,7 +2,6 @@
 #include "ui_importmbcdialog.h"
 
 #include "fileselectionhelper.h"
-#include "graphdatamodel.h"
 #include "guimodel.h"
 #include "mbcfileimporter.h"
 #include "mbcheader.h"
@@ -11,16 +10,12 @@
 
 #include <QFileDialog>
 
-ImportMbcDialog::ImportMbcDialog(GuiModel* pGuiModel,
-                                 GraphDataModel* pGraphDataModel,
-                                 MbcRegisterModel* pMbcRegisterModel,
-                                 QWidget* parent)
+ImportMbcDialog::ImportMbcDialog(GuiModel* pGuiModel, MbcRegisterModel* pMbcRegisterModel, QWidget* parent)
     : QDialog(parent), _pUi(new Ui::ImportMbcDialog)
 {
     _pUi->setupUi(this);
 
     _pGuiModel = pGuiModel;
-    _pGraphDataModel = pGraphDataModel;
     _pMbcRegisterModel = pMbcRegisterModel;
 
     _pTabProxyFilter = new MbcRegisterFilter();

--- a/src/dialogs/importmbcdialog.h
+++ b/src/dialogs/importmbcdialog.h
@@ -7,7 +7,6 @@
 
 /* Forward declaration */
 class GuiModel;
-class GraphDataModel;
 
 namespace Ui {
 class ImportMbcDialog;
@@ -18,7 +17,7 @@ class ImportMbcDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ImportMbcDialog(GuiModel * pGuiModel, GraphDataModel * pGraphDataModel, MbcRegisterModel * pMbcRegisterModel, QWidget *parent = nullptr);
+    explicit ImportMbcDialog(GuiModel* pGuiModel, MbcRegisterModel* pMbcRegisterModel, QWidget* parent = nullptr);
     ~ImportMbcDialog();
 
 public slots:
@@ -38,7 +37,6 @@ private:
     Ui::ImportMbcDialog *_pUi;
 
     GuiModel * _pGuiModel;
-    GraphDataModel * _pGraphDataModel;
     MbcRegisterModel * _pMbcRegisterModel;
 
     MbcRegisterFilter * _pTabProxyFilter;

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -535,7 +535,7 @@ void MainWindow::showMbcImportDialog()
     {
         QList<GraphData> regList = mbcRegisterModel.selectedRegisterList();
 
-        if (regList.size() > 0)
+        if (!regList.isEmpty())
         {
             _pGraphDataModel->add(regList);
         }

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -1,32 +1,34 @@
 #include "mainwindow.h"
-#include "expressionstatus.h"
-#include "communicationstats.h"
-#include "ui_mainwindow.h"
-#include "qcustomplot.h"
-#include "graphdatahandler.h"
-#include "modbuspoll.h"
-#include "graphdatamodel.h"
-#include "notemodel.h"
-#include "diagnosticmodel.h"
-#include "registerdialog.h"
-#include "connectiondialog.h"
-#include "notesdock.h"
-#include "settingsmodel.h"
-#include "dataparsermodel.h"
-#include "logdialog.h"
-#include "diagnosticdialog.h"
 #include "aboutdialog.h"
-#include "markerinfo.h"
-#include "guimodel.h"
-#include "graphview.h"
+#include "communicationstats.h"
+#include "connectiondialog.h"
 #include "datafilehandler.h"
+#include "dataparsermodel.h"
+#include "diagnosticdialog.h"
+#include "diagnosticmodel.h"
+#include "expressionstatus.h"
+#include "fileselectionhelper.h"
+#include "graphdatahandler.h"
+#include "graphdatamodel.h"
+#include "graphview.h"
+#include "guimodel.h"
+#include "importmbcdialog.h"
+#include "logdialog.h"
+#include "markerinfo.h"
+#include "mbcregistermodel.h"
+#include "modbuspoll.h"
+#include "mostrecentmenu.h"
+#include "notemodel.h"
+#include "notesdock.h"
 #include "projectfilehandler.h"
+#include "qcustomplot.h"
+#include "registerdialog.h"
+#include "scopelogging.h"
+#include "settingsmodel.h"
+#include "statusbar.h"
+#include "ui_mainwindow.h"
 #include "util.h"
 #include "versiondownloader.h"
-#include "fileselectionhelper.h"
-#include "scopelogging.h"
-#include "statusbar.h"
-#include "mostrecentmenu.h"
 
 #include <QDateTime>
 
@@ -85,6 +87,7 @@ MainWindow::MainWindow(QStringList cmdArguments, GuiModel* pGuiModel,
     connect(_pUi->actionOpenProjectFile, &QAction::triggered, _pProjectFileHandler, &ProjectFileHandler::selectProjectOpenFile);
     connect(_pUi->actionReloadProjectFile, &QAction::triggered, _pProjectFileHandler, &ProjectFileHandler::reloadProjectFile);
     connect(_pUi->actionOpenDataFile, &QAction::triggered, _pDataFileHandler, &DataFileHandler::selectDataImportFile);
+    connect(_pUi->actionImportFromMbcFile, &QAction::triggered, this, &MainWindow::showMbcImportDialog);
     connect(_pUi->actionExportImage, &QAction::triggered, this, &MainWindow::selectImageExportFile);
     connect(_pUi->actionSaveProjectFileAs, &QAction::triggered, _pProjectFileHandler, &ProjectFileHandler::selectProjectSaveFile);
     connect(_pUi->actionSaveProjectFile, &QAction::triggered, _pProjectFileHandler, &ProjectFileHandler::saveProjectFile);
@@ -397,7 +400,7 @@ void MainWindow::showRegisterDialog(QString mbcFile)
     else
     {
         _pGuiModel->setLastMbcImportedFile(mbcFile);
-        registerDialog.execWithMbcImport();
+        showMbcImportDialog();
     }
 }
 
@@ -521,6 +524,22 @@ void MainWindow::showDiagnostic()
 void MainWindow::showNotesDialog()
 {
     _pNotesDock->show();
+}
+
+void MainWindow::showMbcImportDialog()
+{
+    MbcRegisterModel mbcRegisterModel;
+    ImportMbcDialog importMbcDialog(_pGuiModel, &mbcRegisterModel, this);
+
+    if (importMbcDialog.exec() == QDialog::Accepted)
+    {
+        QList<GraphData> regList = mbcRegisterModel.selectedRegisterList();
+
+        if (regList.size() > 0)
+        {
+            _pGraphDataModel->add(regList);
+        }
+    }
 }
 
 void MainWindow::toggleMarkersState()
@@ -660,6 +679,7 @@ void MainWindow::updateGuiState()
         _pUi->actionRegisterSettings->setEnabled(true);
         _pUi->actionStart->setEnabled(true);
         _pUi->actionOpenDataFile->setEnabled(true);
+        _pUi->actionImportFromMbcFile->setEnabled(true);
         _pUi->actionOpenProjectFile->setEnabled(true);
         _pUi->actionSaveDataFile->setEnabled(false);
         _pUi->actionExportImage->setEnabled(false);
@@ -680,6 +700,7 @@ void MainWindow::updateGuiState()
         _pUi->actionRegisterSettings->setEnabled(false);
         _pUi->actionStart->setEnabled(false);
         _pUi->actionOpenDataFile->setEnabled(false);
+        _pUi->actionImportFromMbcFile->setEnabled(false);
         _pUi->actionOpenProjectFile->setEnabled(false);
         _pUi->actionSaveDataFile->setEnabled(false);
         _pUi->actionSaveProjectFileAs->setEnabled(false);
@@ -697,6 +718,7 @@ void MainWindow::updateGuiState()
         _pUi->actionRegisterSettings->setEnabled(true);
         _pUi->actionStart->setEnabled(true);
         _pUi->actionOpenDataFile->setEnabled(true);
+        _pUi->actionImportFromMbcFile->setEnabled(true);
         _pUi->actionOpenProjectFile->setEnabled(true);
         _pUi->actionSaveDataFile->setEnabled(true);
         _pUi->actionSaveProjectFileAs->setEnabled(true);
@@ -725,6 +747,7 @@ void MainWindow::updateGuiState()
         _pUi->actionRegisterSettings->setEnabled(true);
         _pUi->actionStart->setEnabled(true);
         _pUi->actionOpenDataFile->setEnabled(true);
+        _pUi->actionImportFromMbcFile->setEnabled(true);
         _pUi->actionOpenProjectFile->setEnabled(true);
 
         _pUi->actionSaveDataFile->setEnabled(false);

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -72,6 +72,7 @@ private slots:
     void stopScope();
     void showDiagnostic();
     void showNotesDialog();
+    void showMbcImportDialog();
     void toggleMarkersState();
     void handleOpenRecentProject(QString projectFile);
 

--- a/src/dialogs/mainwindow.ui
+++ b/src/dialogs/mainwindow.ui
@@ -54,13 +54,14 @@
     </property>
     <widget class="QMenu" name="menuMostRecentProject">
      <property name="title">
-      <string>Open &amp;Recent Project</string>
+      <string>Open Recent Project</string>
      </property>
     </widget>
     <addaction name="actionOpenProjectFile"/>
     <addaction name="menuMostRecentProject"/>
     <addaction name="actionReloadProjectFile"/>
     <addaction name="actionOpenDataFile"/>
+    <addaction name="actionImportFromMbcFile"/>
     <addaction name="separator"/>
     <addaction name="actionSaveProjectFile"/>
     <addaction name="actionSaveProjectFileAs"/>
@@ -509,6 +510,11 @@
    </property>
    <property name="text">
     <string>Save &amp;Project</string>
+   </property>
+  </action>
+  <action name="actionImportFromMbcFile">
+   <property name="text">
+    <string>&amp;Import MBC File...</string>
    </property>
   </action>
  </widget>

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -63,7 +63,6 @@ RegisterDialog::RegisterDialog(GuiModel *pGuiModel, GraphDataModel * pGraphDataM
     connect(shortcut, &QShortcut::activated, this, &RegisterDialog::removeRegisterRow);
 
     // Setup handler for buttons
-    connect(_pUi->btnImportFromMbc, &QPushButton::released, this, &RegisterDialog::showImportDialog);
     connect(_pUi->btnAdd, &QPushButton::released, this, &RegisterDialog::addDefaultRegister);
     connect(_pUi->btnRemove, &QPushButton::released, this, &RegisterDialog::removeRegisterRow);
     connect(_pGraphDataModel, &GraphDataModel::rowsInserted, this, &RegisterDialog::onRegisterInserted);
@@ -81,13 +80,6 @@ RegisterDialog::~RegisterDialog()
     delete _pUi;
 }
 
-int RegisterDialog::execWithMbcImport()
-{
-    showImportDialog();
-
-    return exec();
-}
-
 void RegisterDialog::addRegister(const GraphData &graphData)
 {
     _pGraphDataModel->add(graphData);
@@ -96,22 +88,6 @@ void RegisterDialog::addRegister(const GraphData &graphData)
 void RegisterDialog::addDefaultRegister()
 {
     _pGraphDataModel->add();
-}
-
-void RegisterDialog::showImportDialog()
-{
-    MbcRegisterModel mbcRegisterModel(_pGraphDataModel);
-    ImportMbcDialog importMbcDialog(_pGuiModel, _pGraphDataModel, &mbcRegisterModel, this);
-
-    if (importMbcDialog.exec() == QDialog::Accepted)
-    {
-        QList<GraphData> regList = mbcRegisterModel.selectedRegisterList();
-
-        if (regList.size() > 0)
-        {
-            _pGraphDataModel->add(regList);
-        }
-    }
 }
 
 void RegisterDialog::activatedCell(QModelIndex modelIndex)

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -24,11 +24,7 @@ public:
     explicit RegisterDialog(GuiModel * pGuiModel, GraphDataModel *pGraphDataModel, SettingsModel* pSettingsModel, QWidget *parent = nullptr);
     ~RegisterDialog();
 
-public slots:
-    int execWithMbcImport();
-
 private slots:
-    void showImportDialog();
     void addRegister(const GraphData &graphData);
     void addDefaultRegister();
     void removeRegisterRow();

--- a/src/dialogs/registerdialog.ui
+++ b/src/dialogs/registerdialog.ui
@@ -17,13 +17,6 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="btnImportFromMbc">
-       <property name="text">
-        <string>Import from MBC file</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Orientation::Horizontal</enum>
@@ -87,7 +80,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>btnImportFromMbc</tabstop>
   <tabstop>btnAdd</tabstop>
   <tabstop>btnRemove</tabstop>
   <tabstop>registerView</tabstop>


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Move the MBC file import functionality from the `ImportMbcDialog` in `registerdialog` to `mainwindow`, including updating the dialog triggers and UI references accordingly.

### Why are these changes being made?
The MBC import functionality needs to be more accessible and integrated directly into the main window operations for a streamlined user experience. By moving this function, we eliminate redundancy and centralize the import logic, which makes it easier to maintain and enhances the application's modularity. This change also declutters the `registerdialog` of a task not directly related to its primary functions.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->