### PR TITLE
Center checkboxes in views

### DIFF
--- a/src/customwidgets/centeredbox.h
+++ b/src/customwidgets/centeredbox.h
@@ -1,0 +1,60 @@
+#ifndef CENTEREDBOX_H
+#define CENTEREDBOX_H
+
+#include <QProxyStyle>
+#include <QStyleOptionViewItem>
+
+// https://wiki.qt.io/Center_a_QCheckBox_or_Decoration_in_an_Itemview
+
+enum
+{
+    CheckAlignmentRole = Qt::UserRole + Qt::CheckStateRole + Qt::TextAlignmentRole,
+    DecorationAlignmentRole = Qt::UserRole + Qt::DecorationRole + Qt::TextAlignmentRole
+};
+
+class CenteredBoxProxyStyle : public QProxyStyle
+{
+public:
+    using QProxyStyle::QProxyStyle;
+    QRect subElementRect(QStyle::SubElement element, const QStyleOption* option, const QWidget* widget) const override
+    {
+        const QRect baseRes = QProxyStyle::subElementRect(element, option, widget);
+        switch (element)
+        {
+        case SE_ItemViewItemCheckIndicator:
+        {
+            const QStyleOptionViewItem* const itemOpt = qstyleoption_cast<const QStyleOptionViewItem*>(option);
+            const QVariant alignData = itemOpt ? itemOpt->index.data(CheckAlignmentRole) : QVariant();
+            if (!alignData.isNull())
+                return QStyle::alignedRect(itemOpt->direction, alignData.value<Qt::Alignment>(), baseRes.size(),
+                                           itemOpt->rect);
+            break;
+        }
+        case SE_ItemViewItemDecoration:
+        {
+            const QStyleOptionViewItem* const itemOpt = qstyleoption_cast<const QStyleOptionViewItem*>(option);
+            const QVariant alignData = itemOpt ? itemOpt->index.data(DecorationAlignmentRole) : QVariant();
+            if (!alignData.isNull())
+                return QStyle::alignedRect(itemOpt->direction, alignData.value<Qt::Alignment>(), baseRes.size(),
+                                           itemOpt->rect);
+            break;
+        }
+        case SE_ItemViewItemFocusRect:
+        {
+            const QStyleOptionViewItem* const itemOpt = qstyleoption_cast<const QStyleOptionViewItem*>(option);
+            const QVariant checkAlignData = itemOpt ? itemOpt->index.data(CheckAlignmentRole) : QVariant();
+            const QVariant decorationAlignData = itemOpt ? itemOpt->index.data(DecorationAlignmentRole) : QVariant();
+            if (!checkAlignData.isNull() ||
+                !decorationAlignData
+                   .isNull()) // when it is not null, then the focus rect should be drawn over the complete cell
+                return option->rect;
+            break;
+        }
+        default:
+            break;
+        }
+        return baseRes;
+    }
+};
+
+#endif // CENTEREDBOX_H

--- a/src/dialogs/importmbcdialog.cpp
+++ b/src/dialogs/importmbcdialog.cpp
@@ -44,6 +44,8 @@ ImportMbcDialog::ImportMbcDialog(GuiModel* pGuiModel, MbcRegisterModel* pMbcRegi
 
     _pUi->tblMbcRegisters->setFocusPolicy(Qt::NoFocus);
 
+    _pUi->tblMbcRegisters->setStyle(&_centeredBoxStyle);
+
     connect(_pUi->btnSelectMbcFile, &QToolButton::clicked, this, &ImportMbcDialog::selectMbcFile);
     connect(_pMbcRegisterModel, &QAbstractItemModel::dataChanged, this, &ImportMbcDialog::registerDataChanged);
     connect(_pTabProxyFilter, &MbcRegisterFilter::dataChanged, this, &ImportMbcDialog::visibleItemsDataChanged);

--- a/src/dialogs/importmbcdialog.h
+++ b/src/dialogs/importmbcdialog.h
@@ -1,9 +1,10 @@
 #ifndef IMPORTMBCDIALOG_H
 #define IMPORTMBCDIALOG_H
 
-#include <QDialog>
-#include "mbcregistermodel.h"
+#include "centeredbox.h"
 #include "mbcregisterfilter.h"
+#include "mbcregistermodel.h"
+#include <QDialog>
 
 /* Forward declaration */
 class GuiModel;
@@ -35,6 +36,8 @@ private:
     void updateMbcRegisters(QString filePath);
 
     Ui::ImportMbcDialog *_pUi;
+
+    CenteredBoxProxyStyle _centeredBoxStyle;
 
     GuiModel * _pGuiModel;
     MbcRegisterModel * _pMbcRegisterModel;

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -58,6 +58,8 @@ RegisterDialog::RegisterDialog(GuiModel *pGuiModel, GraphDataModel * pGraphDataM
     // Handle cell active signal
     connect(_pUi->registerView, &QTableView::activated, this, &RegisterDialog::activatedCell);
 
+    _pUi->registerView->setStyle(&_centeredBoxStyle);
+
     // Handle delete
     QShortcut* shortcut = new QShortcut(QKeySequence(QKeySequence::Delete), _pUi->registerView);
     connect(shortcut, &QShortcut::activated, this, &RegisterDialog::removeRegisterRow);

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -4,6 +4,8 @@
 #include <QDialog>
 #include <QWidgetAction>
 
+#include "centeredbox.h"
+
 /* Forward declaration */
 class GraphDataModel;
 class GuiModel;
@@ -41,6 +43,8 @@ private:
     GraphDataModel* _pGraphDataModel;
     GuiModel* _pGuiModel;
     SettingsModel* _pSettingsModel;
+
+    CenteredBoxProxyStyle _centeredBoxStyle;
 
     std::unique_ptr<RegisterValueAxisDelegate> _valueAxisDelegate;
     std::unique_ptr<ExpressionDelegate> _expressionDelegate;

--- a/src/models/graphdatamodel.cpp
+++ b/src/models/graphdatamodel.cpp
@@ -2,6 +2,7 @@
 #include "graphdata.h"
 #include "util.h"
 
+#include "centeredbox.h"
 #include "graphdatamodel.h"
 
 const QColor GraphDataModel::lightRed = QColor(255, 0, 0, 127);
@@ -60,6 +61,14 @@ QVariant GraphDataModel::data(const QModelIndex &index, int role) const
             {
                 return Qt::Unchecked;
             }
+        }
+        else if (role == CheckAlignmentRole)
+        {
+            return Qt::AlignCenter;
+        }
+        else
+        {
+            // nothing to do
         }
         break;
     case column::TEXT:

--- a/src/models/mbcregistermodel.cpp
+++ b/src/models/mbcregistermodel.cpp
@@ -1,4 +1,5 @@
 #include "mbcregistermodel.h"
+#include "centeredbox.h"
 
 MbcRegisterModel::MbcRegisterModel(QObject *parent)
     : QAbstractTableModel(parent)
@@ -112,6 +113,13 @@ QVariant MbcRegisterModel::data(const QModelIndex &index, int role) const
             {
                 return Qt::Unchecked;
             }
+        }
+    }
+    else if (role == CheckAlignmentRole)
+    {
+        if (index.column() == cColumnSelected)
+        {
+            return Qt::AlignCenter;
         }
     }
     else if (role == Qt::DisplayRole)


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a `CenteredBoxProxyStyle` class to ensure checkboxes are centered within item views across multiple dialogs.

### Why are these changes being made?
The existing implementation does not center checkboxes in item views, leading to inconsistent UI appearance. This change introduces a `CenteredBoxProxyStyle` to redefine `subElementRect` and use alignment roles, ensuring that checkboxes and decorations appear centered, thus enhancing the visual consistency and UX of the dialogs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->