### PR TITLE
Use previous MinGW (for Qt 6.7.3)

### DIFF
--- a/scripts/setup_windows.bat
+++ b/scripts/setup_windows.bat
@@ -28,7 +28,8 @@ REM Install Qt
 aqt install-qt --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% %QT% %QT_ARCH%  -m %QT_MODULES%
 
 REM Install Tools
-aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_mingw1310
+REM Qt 6.7.x uses mingw 11.2.0 (GCC 9.0) (https://wiki.qt.io/MinGW)
+aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_mingw90
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_cmake
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_ninja
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_opensslv3_x64
@@ -41,7 +42,7 @@ dir %QT_INSTALL_DIR%\Tools
 
 REM Set env variables with path
 set "PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\bin;%PATH%"
-set "PATH=%QT_INSTALL_DIR%\Tools\mingw1310_64\bin;%PATH%"
+set "PATH=%QT_INSTALL_DIR%\Tools\mingw1120_64\bin;%PATH%"
 set "PATH=%QT_INSTALL_DIR%\Tools\CMake_64\bin;%PATH%"
 set "PATH=%QT_INSTALL_DIR%\Tools\Ninja;%PATH%"
 


### PR DESCRIPTION
Latest MinGW is only available with Qt 6.8.x

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the MinGW toolchain in the setup script for Qt 6.7.3 to use MinGW version 11.2.0 (GCC 9.0) instead of 13.10.

### Why are these changes being made?

Qt version 6.7.x utilizes MinGW 11.2.0 according to the Qt documentation, ensuring compatibility and alignment with the recommended toolchain version to potentially avoid build and runtime issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->