### PR TITLE
Force light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The latest *ModbusScope* installer or standalone version can always be downloade
 
 ### Fixed
 
-* xx
+* Always use light mode even when system is configured as dark mode ([Github #372](https://github.com/ModbusScope/ModbusScope/issues/372))
 
 ### Changed
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,9 @@
 
 int main(int argc, char *argv[])
 {
+    // TODO: When porting to Qt 6.8, replace with QStyleHints::setColorScheme(Qt::ColorScheme scheme)
+    qputenv("QT_QPA_PLATFORM", "windows:darkmode=0");
+
     QApplication a(argc, argv);
     QCoreApplication::setOrganizationName("ModbusScope");
     QCoreApplication::setApplicationName("ModbusScope");


### PR DESCRIPTION
Closes #372

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Force the application to always use light mode, regardless of the system's dark mode setting.

### Why are these changes being made?

Users reported that the application was not usable in dark mode due to certain UI elements becoming invisible. This change resolves that issue by ensuring consistent display in light mode. A temporary solution using `qputenv` is applied until an upgrade to Qt 6.8 allows for a more robust implementation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->