### PR TITLE
Pin minor versions of actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: docker://jgeudens/qt-linux:6.7.3_build_2
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0
 
       - name: Start display server
         run: bash /start.sh &
@@ -24,7 +24,7 @@ jobs:
       - name: Deploy
         run: bash scripts/deploy_linux.sh
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6
         with:
           name: modbusscope-linux
           path: ModbusScope*.AppImage
@@ -33,14 +33,14 @@ jobs:
     runs-on: windows-2022
     
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0
 
       - name: Install Qt installer
         run: pip3 install aqtinstall==3.2.0
 
       # Cache go build cache, used to speedup go test
       - name: Qt Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2
         id: cache
         with:
           path: ${{ github.workspace }}\Qt
@@ -50,7 +50,7 @@ jobs:
         shell: cmd
         run: scripts\full_build_and_deploy_windows.bat '${{ steps.cache.outputs.cache-hit }}' ${{ github.workspace }}\Qt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6
         with:
           name: modbusscope-windows
           path: |

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,7 +15,7 @@ jobs:
     container: docker://jgeudens/qt-linux:6.7.3_build_2
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v5.0
 
     - name: Start display server
       run: bash /start.sh &
@@ -34,7 +34,7 @@ jobs:
         gcovr --gcov-ignore-parse-errors --cobertura cobertura.xml
 
     - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@v1
+      uses: codacy/codacy-coverage-reporter-action@v1.3
       with:
         api-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         language: 'CPP'
@@ -49,7 +49,7 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v5.0
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0

--- a/.github/workflows/dfetch.yml
+++ b/.github/workflows/dfetch.yml
@@ -11,10 +11,10 @@ jobs:
       
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v5.0
 
     - name: Set up python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.6
       with:
         python-version: "3.10"
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,14 +10,14 @@ jobs:
     container:
       image: docker://jgeudens/doc-latex:20250124_build_1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0
 
       - name: Build doc
         run: |
           sh create_doc.sh
           mv docs/manual/_build/latex/modbusscope.pdf modbusscope-user-manual.pdf
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6
         with:
           name: modbusscope-user-manual
           path: modbusscope-user-manual.pdf


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Pin the minor versions of GitHub Actions dependencies in various workflow YAML files.

### Why are these changes being made?

This change ensures stability and consistency in the CI/CD pipeline by locking the actions to specific minor versions, thereby preventing unplanned updates that might introduce breaking changes. Using specific minor versions helps avoid potential disruptions caused by major updates while still allowing for critical patches and bug fixes within these versions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->