### PR TITLE
Fix SonarQube

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -58,7 +58,7 @@ jobs:
       uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5.3
     - name: Run build-wrapper
       run: |
-        #here goes your compilation wrapped with build-wrapper; See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-steps-using-build-wrapper for more information
+        # here goes your compilation wrapped with build-wrapper; See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-steps-using-build-wrapper for more information
         cmake . -GNinja
         build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ninja
 
@@ -70,5 +70,5 @@ jobs:
       with:
         # Consult https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/ for more information and options
         args: >
-          --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" 
+          --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix formatting and quoting in the SonarQube CI workflow:
- Add a space after the comment marker in the build-wrapper step.
- Remove unnecessary quotes around the compile-commands path in SonarQube analysis arguments.

### Why are these changes being made?
To align with recommended formatting and ensure the SonarQube scanner receives the compile-commands path correctly. The changes improve readability and prevent potential parsing issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->