### PR TITLE
Update dfetch.yml

### DIFF
--- a/.github/workflows/dfetch.yml
+++ b/.github/workflows/dfetch.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up dfetch
       run: |
          python -m pip install --upgrade pip
-         pip install https://github.com/dfetch-org/dfetch/archive/main.zip
+         pip install git+https://github.com/dfetch-org/dfetch.git#egg=dfetch
 
     - name: Check dependencies
       run: dfetch check --sarif sarif.json


### PR DESCRIPTION
Dfetch uses setuptools-scm, use git+https instead of .zip

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Install dfetch from the git repository via pip instead of downloading the latest zip from GitHub.

### Why are these changes being made?
Switch the installation source to the git repository to ensure the latest code is used. This avoids issues with the archive URL and aligns the workflow with the project’s preferred install method.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->