### PR TITLE
Fix reading same register address on multiple devices on same serial connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The latest *ModbusScope* installer or standalone version can always be downloade
 
 ### Fixed
 
-* xx
+* Fix incorrect data displayed when polling multiple devices on the same connection (e.g. multiple slave IDs on a serial bus)
 
 ### Changed
 

--- a/src/communication/modbusdataunit.cpp
+++ b/src/communication/modbusdataunit.cpp
@@ -1,5 +1,7 @@
 #include "modbusdataunit.h"
 
+#include <tuple>
+
 ModbusDataUnit::ModbusDataUnit(quint16 protocolAddress, ObjectType type, slaveId_t slaveId)
     : ModbusAddress(protocolAddress, type), _slaveId(slaveId)
 {
@@ -44,34 +46,6 @@ bool operator==(const ModbusDataUnit& unit1, const ModbusDataUnit& unit2)
 
 bool operator<(const ModbusDataUnit& unit1, const ModbusDataUnit& unit2)
 {
-    if (unit1._slaveId < unit2._slaveId)
-    {
-        return true;
-    }
-    else if (unit1._slaveId == unit2._slaveId)
-    {
-        if (unit1._type < unit2._type)
-        {
-            return true;
-        }
-        else if (unit1._type == unit2._type)
-        {
-            if (unit1._protocolAddress < unit2._protocolAddress)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        else
-        {
-            return false;
-        }
-    }
-    else
-    {
-        return false;
-    }
+    return std::tie(unit1._slaveId, unit1._type, unit1._protocolAddress)
+         < std::tie(unit2._slaveId, unit2._type, unit2._protocolAddress);
 }

--- a/src/communication/modbusdataunit.cpp
+++ b/src/communication/modbusdataunit.cpp
@@ -33,15 +33,8 @@ QString ModbusDataUnit::toString() const
 
 bool operator==(const ModbusDataUnit& unit1, const ModbusDataUnit& unit2)
 {
-    if ((unit1._protocolAddress == unit2._protocolAddress) && (unit1._type == unit2._type) &&
-        (unit1._slaveId == unit2._slaveId))
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return std::tie(unit1._slaveId, unit1._type, unit1._protocolAddress)
+        == std::tie(unit2._slaveId, unit2._type, unit2._protocolAddress);
 }
 
 bool operator<(const ModbusDataUnit& unit1, const ModbusDataUnit& unit2)

--- a/src/communication/modbusdataunit.cpp
+++ b/src/communication/modbusdataunit.cpp
@@ -44,15 +44,26 @@ bool operator==(const ModbusDataUnit& unit1, const ModbusDataUnit& unit2)
 
 bool operator<(const ModbusDataUnit& unit1, const ModbusDataUnit& unit2)
 {
-    if (unit1._type < unit2._type)
+    if (unit1._slaveId < unit2._slaveId)
     {
         return true;
     }
-    else if (unit1._type == unit2._type)
+    else if (unit1._slaveId == unit2._slaveId)
     {
-        if (unit1._protocolAddress < unit2._protocolAddress)
+        if (unit1._type < unit2._type)
         {
             return true;
+        }
+        else if (unit1._type == unit2._type)
+        {
+            if (unit1._protocolAddress < unit2._protocolAddress)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
         else
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,10 +33,7 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS
 function(add_xtest SOURCE_NAME)
 	add_executable(${SOURCE_NAME}
         ${SOURCE_NAME}.cpp
-		${ARGV1}
-		${ARGV2}
-        ${ARGV3}
-        ${ARGV4})
+		${ARGN})
 	target_link_libraries(${SOURCE_NAME} Qt::Test ${QT_LIB} ${SCOPESOURCE})
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
 endfunction()
@@ -45,10 +42,7 @@ function(add_xtest_mock SOURCE_NAME)
 	add_executable(${SOURCE_NAME}
         ${SOURCE_NAME}.cpp
         ${GOOGLE_TEST_SOURCE}
-		${ARGV1}
-		${ARGV2}
-        ${ARGV3}
-        ${ARGV4})
+		${ARGN})
 	target_link_libraries(${SOURCE_NAME} Qt::Test Threads::Threads ${QT_LIB} ${SCOPESOURCE})
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
 endfunction()

--- a/tests/communication/CMakeLists.txt
+++ b/tests/communication/CMakeLists.txt
@@ -2,6 +2,7 @@
 SET(TEST_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/../testslave/testslavedata.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../testslave/testslavemodbus.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../testslave/testslavemodbusmulti.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../testslave/testdevice.cpp
 )
 

--- a/tests/communication/tst_modbusdataunit.cpp
+++ b/tests/communication/tst_modbusdataunit.cpp
@@ -58,11 +58,29 @@ void TestModbusDataUnit::operator_less_than()
     ModbusDataUnit unit1(10, ModbusAddress::ObjectType::COIL, 5);
     ModbusDataUnit unit2(11, ModbusAddress::ObjectType::COIL, 5);
     ModbusDataUnit unit3(10, ModbusAddress::ObjectType::DISCRETE_INPUT, 5);
+    ModbusDataUnit unit4(10, ModbusAddress::ObjectType::COIL, 6); // same addr+type, different slaveId
 
     QVERIFY(unit1 < unit2); // protocolAddress comparison
     QVERIFY(unit1 < unit3); // type comparison
     QVERIFY(!(unit2 < unit1));
     QVERIFY(!(unit3 < unit1));
+    // slaveId comparison (regression for multi-slave bug)
+    QVERIFY(unit1 < unit4); // slaveId 5 < slaveId 6, same address+type
+    QVERIFY(!(unit4 < unit1));
+}
+
+void TestModbusDataUnit::qmap_different_slave_ids_are_distinct_keys()
+{
+    ModbusDataUnit unit1(40001, ModbusAddress::ObjectType::HOLDING_REGISTER, 1);
+    ModbusDataUnit unit2(40001, ModbusAddress::ObjectType::HOLDING_REGISTER, 2);
+
+    QMap<ModbusDataUnit, int> map;
+    map.insert(unit1, 100);
+    map.insert(unit2, 200);
+
+    QCOMPARE(map.size(), 2);
+    QCOMPARE(map.value(unit1), 100);
+    QCOMPARE(map.value(unit2), 200);
 }
 
 void TestModbusDataUnit::toString()

--- a/tests/communication/tst_modbusdataunit.h
+++ b/tests/communication/tst_modbusdataunit.h
@@ -15,6 +15,7 @@ private slots:
 
     void operator_equality();
     void operator_less_than();
+    void qmap_different_slave_ids_are_distinct_keys();
 
     void toString();
 

--- a/tests/communication/tst_modbuspoll.cpp
+++ b/tests/communication/tst_modbuspoll.cpp
@@ -4,6 +4,7 @@
 #include "communication/modbuspoll.h"
 #include "communicationhelpers.h"
 #include "testslavemodbus.h"
+#include "testslavemodbusmulti.h"
 #include "util/modbusdatatype.h"
 
 #include <QSignalSpy>
@@ -338,6 +339,53 @@ void TestModbusPoll::multiSlaveSuccess_3()
 
     /* Verify arguments of signal */
     CommunicationHelpers::verifyReceivedDataSignal(arguments, expResults);
+}
+
+void TestModbusPoll::multiSlaveSameConnectionSameAddress()
+{
+    /* Reproduce the reported bug: two slaves with different IDs share the same
+     * connection (same port) and both read the same register address.
+     * Before the operator< fix, both curves showed the value from the last-polled
+     * slave because the result map treated (addr=40001, slaveId=1) and
+     * (addr=40001, slaveId=4) as the same key. */
+
+    const quint8 newSlaveId = 4;
+    const deviceId_t newDevId = Device::cFirstDeviceId + 3;
+
+    /* Replace the single-slave server at port 5020 with a multi-slave server
+     * that responds to slave ID 1 (device 1) and slave ID 4 (new device) */
+    _testSlaveMap[Device::cFirstDeviceId]->disconnect();
+
+    TestSlaveMultiModbus multiSlave;
+    QVERIFY(multiSlave.listenOnPort(5020));
+
+    multiSlave.testDevice(Device::cFirstDeviceId)->configureHoldingRegister(0, true, 1111);
+    multiSlave.testDevice(newSlaveId)->configureHoldingRegister(0, true, 4444);
+
+    /* Add a 4th device that shares connection ID_1 (port 5020) with device 1 */
+    _pSettingsModel->addDevice(newDevId);
+    _pSettingsModel->deviceSettings(newDevId)->setConnectionId(ConnectionTypes::ID_1);
+    _pSettingsModel->deviceSettings(newDevId)->setSlaveId(newSlaveId);
+
+    ModbusPoll modbusPoll(_pSettingsModel);
+    QSignalSpy spyDataReady(&modbusPoll, &ModbusPoll::registerDataReady);
+
+    auto modbusRegisters = QList<ModbusRegister>()
+                           << ModbusRegister(ModbusAddress(40001), Device::cFirstDeviceId, Type::UNSIGNED_16)
+                           << ModbusRegister(ModbusAddress(40001), newDevId, Type::UNSIGNED_16);
+
+    modbusPoll.startCommunication(modbusRegisters);
+
+    QVERIFY(spyDataReady.wait(500));
+    QCOMPARE(spyDataReady.count(), 1);
+
+    QList<QVariant> arguments = spyDataReady.takeFirst();
+    auto expResults = ResultDoubleList() << ResultDouble(1111, State::SUCCESS)
+                                         << ResultDouble(4444, State::SUCCESS);
+
+    CommunicationHelpers::verifyReceivedDataSignal(arguments, expResults);
+
+    multiSlave.stopListening();
 }
 
 void TestModbusPoll::multiSlaveSingleFail()

--- a/tests/communication/tst_modbuspoll.h
+++ b/tests/communication/tst_modbuspoll.h
@@ -25,6 +25,7 @@ private slots:
     void multiSlaveSuccess();
     void multiSlaveSuccess_2();
     void multiSlaveSuccess_3();
+    void multiSlaveSameConnectionSameAddress();
     void multiSlaveSingleFail();
     void multiSlaveAllFail();
 

--- a/tests/communication/tst_registervaluehandler.cpp
+++ b/tests/communication/tst_registervaluehandler.cpp
@@ -291,10 +291,10 @@ void TestRegisterValueHandler::readConnections()
                            << ModbusRegister(ModbusAddress(40001), Device::cFirstDeviceId, Type::UNSIGNED_16)
                            << ModbusRegister(ModbusAddress(40001), Device::cFirstDeviceId + 1, Type::SIGNED_16);
     ModbusResultMap partialResultMap1;
-    addToResultMap(partialResultMap1, 40001, false, 256, State::SUCCESS);
+    addToResultMap(partialResultMap1, 40001, false, 256, State::SUCCESS, 1);
 
     ModbusResultMap partialResultMap2;
-    addToResultMap(partialResultMap2, 40001, false, 100, State::SUCCESS);
+    addToResultMap(partialResultMap2, 40001, false, 100, State::SUCCESS, 2);
 
     auto expResults = ResultDoubleList() << ResultDouble(256, State::SUCCESS)
                                             << ResultDouble(100, State::SUCCESS);
@@ -329,7 +329,7 @@ void TestRegisterValueHandler::readFail()
                            << ModbusRegister(ModbusAddress(40001), Device::cFirstDeviceId + 1, Type::SIGNED_16);
 
     ModbusResultMap partialResultMap2;
-    addToResultMap(partialResultMap2, 40001, false, 100, State::SUCCESS);
+    addToResultMap(partialResultMap2, 40001, false, 100, State::SUCCESS, 2);
 
     auto expResults = ResultDoubleList() << ResultDouble(0, State::INVALID)
                                             << ResultDouble(100, State::SUCCESS);
@@ -385,14 +385,15 @@ void TestRegisterValueHandler::addToResultMap(ModbusResultMap &resultMap,
         quint32 addr,
         bool b32bit,
         qint64 value,
-        State resultState
+        State resultState,
+        ModbusDataUnit::slaveId_t slaveId
         )
 {
-    resultMap.insert(ModbusDataUnit(addr), Result<quint16>(static_cast<quint16>(value), resultState));
+    resultMap.insert(ModbusDataUnit(addr, ModbusAddress::ObjectType::UNKNOWN, slaveId), Result<quint16>(static_cast<quint16>(value), resultState));
 
     if (b32bit)
     {
-        resultMap.insert(ModbusDataUnit(addr + 1), Result<quint16>(static_cast<quint32>(value) >> 16, resultState));
+        resultMap.insert(ModbusDataUnit(addr + 1, ModbusAddress::ObjectType::UNKNOWN, slaveId), Result<quint16>(static_cast<quint32>(value) >> 16, resultState));
     }
 }
 

--- a/tests/communication/tst_registervaluehandler.h
+++ b/tests/communication/tst_registervaluehandler.h
@@ -45,7 +45,8 @@ private:
             quint32 addr,
             bool b32bit,
             qint64 value,
-            ResultState::State resultState
+            ResultState::State resultState,
+            ModbusDataUnit::slaveId_t slaveId = 1
             );
 
     SettingsModel* _pSettingsModel;

--- a/tests/testslave/testslavemodbusmulti.cpp
+++ b/tests/testslave/testslavemodbusmulti.cpp
@@ -50,7 +50,10 @@ void TestSlaveMultiModbus::incomingConnection(qintptr socketDescriptor)
     auto* socket = new QTcpSocket(this);
     socket->setSocketDescriptor(socketDescriptor);
     connect(socket, &QTcpSocket::readyRead, this, &TestSlaveMultiModbus::handleReadyRead);
-    connect(socket, &QTcpSocket::disconnected, socket, &QTcpSocket::deleteLater);
+    connect(socket, &QTcpSocket::disconnected, this, [this, socket]() {
+        _sockets.removeOne(socket);
+        socket->deleteLater();
+    });
     _sockets.append(socket);
 }
 
@@ -72,7 +75,7 @@ void TestSlaveMultiModbus::handleReadyRead()
             break;
         }
 
-        const QByteArray frame = socket->read(MBAP_SIZE + length);
+        const QByteArray frame = socket->read(MBAP_SIZE + length); // NOLINT(clang-analyzer-security.insecureAPI*)
         processFrame(socket, frame);
     }
 }
@@ -80,7 +83,7 @@ void TestSlaveMultiModbus::handleReadyRead()
 void TestSlaveMultiModbus::processFrame(QTcpSocket* socket, const QByteArray& frame)
 {
     /* Minimum: MBAP (6) + unit ID (1) + function code (1) + 2-byte address + 2-byte quantity */
-    if (frame.size() < MBAP_SIZE + 5)
+    if (frame.size() < MBAP_SIZE + 6)
     {
         return;
     }

--- a/tests/testslave/testslavemodbusmulti.cpp
+++ b/tests/testslave/testslavemodbusmulti.cpp
@@ -1,0 +1,130 @@
+#include "testslavemodbusmulti.h"
+
+#include <QHostAddress>
+#include <QModbusDataUnit>
+
+/* Modbus TCP frame layout:
+ *   Bytes 0-1 : Transaction Identifier
+ *   Bytes 2-3 : Protocol Identifier (0x0000)
+ *   Bytes 4-5 : Length (number of bytes that follow, including Unit ID)
+ *   Byte  6   : Unit Identifier (slave ID)
+ *   Byte  7+  : PDU (function code + data)
+ */
+static const int MBAP_SIZE = 6;
+
+TestSlaveMultiModbus::TestSlaveMultiModbus(QObject* parent) : QTcpServer(parent)
+{
+}
+
+TestSlaveMultiModbus::~TestSlaveMultiModbus()
+{
+    qDeleteAll(_devices);
+}
+
+bool TestSlaveMultiModbus::listenOnPort(quint16 port)
+{
+    return listen(QHostAddress::LocalHost, port);
+}
+
+void TestSlaveMultiModbus::stopListening()
+{
+    for (auto* socket : std::as_const(_sockets))
+    {
+        socket->disconnectFromHost();
+    }
+    _sockets.clear();
+    close();
+}
+
+TestDevice* TestSlaveMultiModbus::testDevice(quint8 slaveId)
+{
+    if (!_devices.contains(slaveId))
+    {
+        _devices.insert(slaveId, new TestDevice(this));
+    }
+    return _devices.value(slaveId);
+}
+
+void TestSlaveMultiModbus::incomingConnection(qintptr socketDescriptor)
+{
+    auto* socket = new QTcpSocket(this);
+    socket->setSocketDescriptor(socketDescriptor);
+    connect(socket, &QTcpSocket::readyRead, this, &TestSlaveMultiModbus::handleReadyRead);
+    connect(socket, &QTcpSocket::disconnected, socket, &QTcpSocket::deleteLater);
+    _sockets.append(socket);
+}
+
+void TestSlaveMultiModbus::handleReadyRead()
+{
+    auto* socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket)
+    {
+        return;
+    }
+
+    while (socket->bytesAvailable() >= MBAP_SIZE)
+    {
+        const QByteArray header = socket->peek(MBAP_SIZE);
+        const quint16 length = (static_cast<quint8>(header[4]) << 8) | static_cast<quint8>(header[5]);
+
+        if (socket->bytesAvailable() < MBAP_SIZE + length)
+        {
+            break;
+        }
+
+        const QByteArray frame = socket->read(MBAP_SIZE + length);
+        processFrame(socket, frame);
+    }
+}
+
+void TestSlaveMultiModbus::processFrame(QTcpSocket* socket, const QByteArray& frame)
+{
+    /* Minimum: MBAP (6) + unit ID (1) + function code (1) + 2-byte address + 2-byte quantity */
+    if (frame.size() < MBAP_SIZE + 5)
+    {
+        return;
+    }
+
+    const quint8 unitId    = static_cast<quint8>(frame[6]);
+    const quint8 fc        = static_cast<quint8>(frame[7]);
+    const quint16 startAddr = (static_cast<quint8>(frame[8]) << 8) | static_cast<quint8>(frame[9]);
+    const quint16 quantity  = (static_cast<quint8>(frame[10]) << 8) | static_cast<quint8>(frame[11]);
+
+    /* Only Read Holding Registers (FC 0x03) is implemented */
+    if (fc != 0x03)
+    {
+        return;
+    }
+
+    /* Response length field: unit ID (1) + FC (1) + byte count (1) + data (2*qty) */
+    const quint16 respLength = 3 + quantity * 2u;
+
+    QByteArray response;
+    response.resize(MBAP_SIZE + respLength);
+
+    response[0] = frame[0]; response[1] = frame[1]; /* Transaction ID */
+    response[2] = 0x00;     response[3] = 0x00;     /* Protocol ID   */
+    response[4] = static_cast<char>((respLength >> 8) & 0xFF);
+    response[5] = static_cast<char>(respLength & 0xFF);
+    response[6] = static_cast<char>(unitId);
+    response[7] = static_cast<char>(fc);
+    response[8] = static_cast<char>((quantity * 2u) & 0xFF); /* Byte count */
+
+    TestDevice* device = _devices.value(unitId, nullptr);
+    for (quint16 i = 0; i < quantity; i++)
+    {
+        quint16 value = 0;
+        if (device)
+        {
+            auto* slaveData = device->slaveData(QModbusDataUnit::HoldingRegisters);
+            if (slaveData && slaveData->registerState(startAddr + i))
+            {
+                value = slaveData->registerValue(startAddr + i);
+            }
+        }
+        response[9 + i * 2]     = static_cast<char>((value >> 8) & 0xFF);
+        response[9 + i * 2 + 1] = static_cast<char>(value & 0xFF);
+    }
+
+    socket->write(response);
+}

--- a/tests/testslave/testslavemodbusmulti.cpp
+++ b/tests/testslave/testslavemodbusmulti.cpp
@@ -96,11 +96,27 @@ void TestSlaveMultiModbus::processFrame(QTcpSocket* socket, const QByteArray& fr
     /* Only Read Holding Registers (FC 0x03) is implemented */
     if (fc != 0x03)
     {
+        /* Modbus exception response: error FC + exception code 0x01 (Illegal Function) */
+        const quint16 excLength = 3u; /* unit ID (1) + error FC (1) + exception code (1) */
+        QByteArray excResponse(MBAP_SIZE + excLength, 0x00);
+        excResponse[0] = frame[0]; excResponse[1] = frame[1]; /* Transaction ID */
+        excResponse[4] = static_cast<char>((excLength >> 8) & 0xFF);
+        excResponse[5] = static_cast<char>(excLength & 0xFF);
+        excResponse[6] = static_cast<char>(unitId);
+        excResponse[7] = static_cast<char>(fc | 0x80);
+        excResponse[8] = 0x01; /* Illegal Function */
+        socket->write(excResponse);
+        return;
+    }
+
+    static const quint16 maxQuantity = 125u; /* Modbus FC 0x03 max registers per request */
+    if (quantity > maxQuantity)
+    {
         return;
     }
 
     /* Response length field: unit ID (1) + FC (1) + byte count (1) + data (2*qty) */
-    const quint16 respLength = 3 + quantity * 2u;
+    const quint32 respLength = 3u + quantity * 2u;
 
     QByteArray response;
     response.resize(MBAP_SIZE + respLength);

--- a/tests/testslave/testslavemodbusmulti.h
+++ b/tests/testslave/testslavemodbusmulti.h
@@ -1,0 +1,40 @@
+#ifndef TESTSLAVEMODBUSMULTI_H
+#define TESTSLAVEMODBUSMULTI_H
+
+#include "testdevice.h"
+
+#include <QTcpServer>
+#include <QTcpSocket>
+
+/*!
+ * Minimal Modbus TCP server that serves multiple slave IDs on a single port.
+ * QModbusTcpServer only handles one slave ID, making it impossible to bind two
+ * instances to the same port. This class implements enough of the Modbus TCP
+ * protocol (Read Holding Registers, FC 0x03) to support multi-slave tests.
+ */
+class TestSlaveMultiModbus : public QTcpServer
+{
+    Q_OBJECT
+public:
+    explicit TestSlaveMultiModbus(QObject* parent = nullptr);
+    ~TestSlaveMultiModbus();
+
+    bool listenOnPort(quint16 port);
+    void stopListening();
+
+    TestDevice* testDevice(quint8 slaveId);
+
+protected:
+    void incomingConnection(qintptr socketDescriptor) override;
+
+private slots:
+    void handleReadyRead();
+
+private:
+    void processFrame(QTcpSocket* socket, const QByteArray& frame);
+
+    QMap<quint8, TestDevice*> _devices;
+    QList<QTcpSocket*> _sockets;
+};
+
+#endif // TESTSLAVEMODBUSMULTI_H


### PR DESCRIPTION
Fix for #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect data display when polling multiple devices (distinct slave IDs) on the same connection.

* **Tests**
  * Added comprehensive multi-slave tests and a lightweight multi-slave test server to validate per-slave data isolation and prevent regressions.

* **Documentation**
  * Updated changelog entry describing the multi-slave polling fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->