### PR TITLE
Make sure connection is always correctly closed

### DIFF
--- a/src/communication/modbusmaster.cpp
+++ b/src/communication/modbusmaster.cpp
@@ -94,11 +94,7 @@ void ModbusMaster::readRegisterList(QList<ModbusDataUnit> registerList, quint8 c
 
 void ModbusMaster::cleanUp()
 {
-    /* Close connection when not closing automatically */
-    if (_pSettingsModel->connectionSettings(_connectionId)->persistentConnection())
-    {
-        _pModbusConnection->close();
-    }
+    _pModbusConnection->close();
 }
 
 void ModbusMaster::handleConnectionOpened()

--- a/tests/communication/tst_modbusmasterfake.cpp
+++ b/tests/communication/tst_modbusmasterfake.cpp
@@ -108,4 +108,23 @@ void TestModbusMasterFake::requestToDevicesOnSameConnection()
     QCOMPARE(result[dataUnit2].value(), static_cast<quint32>(5));
 }
 
+void TestModbusMasterFake::cleanUpClosesConnectionAlways()
+{
+    /* Verify that cleanUp() always closes the connection, even when persistentConnection=false.
+     * Bug: with non-persistent connections, cleanUp() did nothing, leaving the serial port
+     * open if called while a read was in-flight. */
+    auto connData = _pSettingsModel->connectionSettings(ConnectionTypes::ID_1);
+    connData->setPersistentConnection(false);
+
+    _testDeviceMap[Device::cFirstDeviceId]->configureHoldingRegister(0, true, 0);
+
+    ModbusConnectionFake* conn = new ModbusConnectionFake(); // ModbusMaster takes ownership
+    conn->addSlaveDevice(Device::cFirstDeviceId, _testDeviceMap[Device::cFirstDeviceId]);
+    ModbusMaster modbusMaster(conn, _pSettingsModel, ConnectionTypes::ID_1);
+
+    modbusMaster.cleanUp();
+
+    QVERIFY(conn->closeCallCount() >= 1);
+}
+
 QTEST_GUILESS_MAIN(TestModbusMasterFake)

--- a/tests/communication/tst_modbusmasterfake.h
+++ b/tests/communication/tst_modbusmasterfake.h
@@ -14,6 +14,8 @@ private slots:
     void singleRequestSuccess();
     void requestToDevicesOnSameConnection();
 
+    void cleanUpClosesConnectionAlways();
+
 private:
     QMap<deviceId_t, TestDevice*> _testDeviceMap;
     SettingsModel* _pSettingsModel;

--- a/tests/testslave/modbusconnectionfake.cpp
+++ b/tests/testslave/modbusconnectionfake.cpp
@@ -47,6 +47,12 @@ void ModbusConnectionFake::open(quint32 timeout)
  */
 void ModbusConnectionFake::close(void)
 {
+    _closeCount++;
+}
+
+quint32 ModbusConnectionFake::closeCallCount() const
+{
+    return _closeCount;
 }
 
 /*!

--- a/tests/testslave/modbusconnectionfake.h
+++ b/tests/testslave/modbusconnectionfake.h
@@ -25,8 +25,11 @@ public:
 
     bool isConnected(void) override;
 
+    quint32 closeCallCount() const;
+
 private:
     SlaveDeviceMap _deviceMap;
+    quint32 _closeCount = 0;
 };
 
 #endif // MODBUSCONNECTIONFAKE_H


### PR DESCRIPTION
Related to #425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the connection cleanup procedure to ensure Modbus connections are consistently and properly closed, regardless of persistence configuration settings, improving resource management.

* **Tests**
  * Added comprehensive test cases to validate connection cleanup behaviour across different persistence configurations and scenarios.
  * Enhanced test utilities to track and verify connection closure operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->