### PR TITLE
fix: parent model objects to MainApp to ensure safe destruction order

### DIFF
--- a/.claude/agents/quality.md
+++ b/.claude/agents/quality.md
@@ -2,7 +2,7 @@
 name: quality
 description: Run pre-commit quality checks (clang-format, clang-tidy, clazy) on source files. Use after making code changes before finishing a task.
 tools: Bash
-model: Haiku
+model: haiku
 effort: low
 ---
 

--- a/Plan/architecture_review.md
+++ b/Plan/architecture_review.md
@@ -138,7 +138,7 @@ These are the most business-critical classes. Changes to `GraphDataModel` in par
 
 ---
 
-### 3.2 `GraphDataHandler` is an unnecessary `QObject`
+### 3.2 `GraphDataHandler` is an unnecessary `QObject` [DONE]
 **File:** `src/datahandling/graphdatahandler.h`
 
 `GraphDataHandler` inherits `QObject` solely to expose one slot (`handleRegisterData`) and emit one signal (`graphDataReady`). The slot just transforms `ResultDoubleList → ResultDoubleList` and the signal is a fan-out. This could be a plain function call or a non-QObject with `std::function` callbacks, eliminating the metaclass overhead and making it trivially testable without the event loop.

--- a/Plan/architecture_review.md
+++ b/Plan/architecture_review.md
@@ -59,7 +59,7 @@ This makes the class ~700 lines, hard to test in isolation, and difficult to ext
 
 ---
 
-### 2.2 `GraphDataModel::dataMap()` leaks mutable internals
+### 2.2 `GraphDataModel::dataMap()` leaks mutable internals [DONE]
 **File:** `src/models/graphdatamodel.h:58`
 
 ```cpp

--- a/Plan/architecture_review.md
+++ b/Plan/architecture_review.md
@@ -109,7 +109,7 @@ A static setter injects a model pointer into a utility class globally. This is h
 
 ---
 
-### 2.6 `ProjectFileHandler` created without Qt parent
+### 2.6 `ProjectFileHandler` created without Qt parent [DONE]
 **File:** `src/dialogs/mainwindow.cpp:69`
 
 ```cpp

--- a/Plan/architecture_review.md
+++ b/Plan/architecture_review.md
@@ -6,7 +6,7 @@
 
 ## 1. Critical Issues
 
-### 1.1 Unsafe object lifetime in `MainApp`
+### 1.1 Unsafe object lifetime in `MainApp` [DONE]
 **File:** `src/mainapp.cpp:48–58`
 
 All six models are allocated without a Qt parent. The destructor manually deletes `MainWindow` _first_ (line 50), then the models (lines 52–57). At the moment `MainWindow` is deleted, it tears down widget children — but all model signals are still live. Qt disconnects them safely during `QObject::~QObject`, so there is no crash today, but the order is fragile and non-obvious. Any future eager access to a model from a widget destructor would be a use-after-free.

--- a/src/customwidgets/markerinfoitem.cpp
+++ b/src/customwidgets/markerinfoitem.cpp
@@ -18,7 +18,7 @@ MarkerInfoItem::MarkerInfoItem(QWidget* parent) : QFrame(parent)
     _pGraphCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
     QWidget* pInfoWidget = new QWidget(this);
-    QHBoxLayout* pInfoLayout = new QHBoxLayout(this);
+    QHBoxLayout* pInfoLayout = new QHBoxLayout(pInfoWidget);
 
     _pGraphDataLabelLeft = new QLabel("", this);
     _pGraphDataLabelRight = new QLabel("", this);
@@ -28,8 +28,6 @@ MarkerInfoItem::MarkerInfoItem(QWidget* parent) : QFrame(parent)
     pInfoLayout->setContentsMargins(0, 2, 0, 0); // This is redundant with setMargin, which is deprecated
     pInfoLayout->addWidget(_pGraphDataLabelLeft);
     pInfoLayout->addWidget(_pGraphDataLabelRight);
-
-    pInfoWidget->setLayout(pInfoLayout);
 
     _pLayout->addWidget(_pGraphCombo);
     _pLayout->addWidget(pInfoWidget);

--- a/src/customwidgets/markerinfoitem.cpp
+++ b/src/customwidgets/markerinfoitem.cpp
@@ -7,7 +7,7 @@
 #include "models/guimodel.h"
 #include "util/util.h"
 
-MarkerInfoItem::MarkerInfoItem(QWidget *parent) : QFrame(parent)
+MarkerInfoItem::MarkerInfoItem(QWidget* parent) : QFrame(parent)
 {
     _pLayout = new QVBoxLayout();
 
@@ -17,8 +17,8 @@ MarkerInfoItem::MarkerInfoItem(QWidget *parent) : QFrame(parent)
     _pGraphCombo = new QComboBox(this);
     _pGraphCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
-    QWidget * pInfoWidget = new QWidget(this);
-    QHBoxLayout *pInfoLayout = new QHBoxLayout(this);
+    QWidget* pInfoWidget = new QWidget(this);
+    QHBoxLayout* pInfoLayout = new QHBoxLayout(this);
 
     _pGraphDataLabelLeft = new QLabel("", this);
     _pGraphDataLabelRight = new QLabel("", this);
@@ -34,12 +34,13 @@ MarkerInfoItem::MarkerInfoItem(QWidget *parent) : QFrame(parent)
     _pLayout->addWidget(_pGraphCombo);
     _pLayout->addWidget(pInfoWidget);
 
-    connect(_pGraphCombo, QOverload<const int>::of(&QComboBox::currentIndexChanged), this, &MarkerInfoItem::graphSelected);
+    connect(_pGraphCombo, QOverload<const int>::of(&QComboBox::currentIndexChanged), this,
+            &MarkerInfoItem::graphSelected);
 
     setLayout(_pLayout);
 }
 
-void MarkerInfoItem::setModel(GuiModel * pGuiModel, GraphDataModel * pGraphDataModel)
+void MarkerInfoItem::setModel(GuiModel* pGuiModel, GraphDataModel* pGraphDataModel)
 {
     _pGuiModel = pGuiModel;
     _pGraphDataModel = pGraphDataModel;
@@ -78,7 +79,7 @@ void MarkerInfoItem::updateData()
     QStringList expressionList;
     const quint32 mask = _pGuiModel->markerExpressionMask();
 
-    for(qint32 idx = 0; idx < GuiModel::cMarkerExpressionBits.size(); idx++)
+    for (qint32 idx = 0; idx < GuiModel::cMarkerExpressionBits.size(); idx++)
     {
         if (mask & GuiModel::cMarkerExpressionBits[idx])
         {
@@ -90,14 +91,16 @@ void MarkerInfoItem::updateData()
     }
 
     /* Add permanent items (y1, y2) */
-    expressionList.prepend(GuiModel::cMarkerExpressionEnd.arg(Util::formatDoubleForExport(dataMap->findBegin(_pGuiModel->endMarkerPos(), false)->value)));
-    expressionList.prepend(GuiModel::cMarkerExpressionStart.arg(Util::formatDoubleForExport(dataMap->findBegin(_pGuiModel->startMarkerPos(), false)->value)));
+    expressionList.prepend(GuiModel::cMarkerExpressionEnd.arg(
+      Util::formatDoubleForExport(dataMap->findBegin(_pGuiModel->endMarkerPos(), false)->value)));
+    expressionList.prepend(GuiModel::cMarkerExpressionStart.arg(
+      Util::formatDoubleForExport(dataMap->findBegin(_pGuiModel->startMarkerPos(), false)->value)));
 
     /* Construct labels data */
     const qint32 leftRowCount = expressionList.size() - expressionList.size() / 2;
     QString graphDataLeft;
     QString graphDataRight;
-    for(qint32 idx = 0; idx < expressionList.size(); idx++)
+    for (qint32 idx = 0; idx < expressionList.size(); idx++)
     {
         if (idx < leftRowCount)
         {
@@ -125,7 +128,7 @@ void MarkerInfoItem::updateGraphList(void)
 
 void MarkerInfoItem::updateColor(quint32 graphIdx)
 {
-    QPixmap pixmap(20,5);
+    QPixmap pixmap(20, 5);
     pixmap.fill(_pGraphDataModel->color(graphIdx));
 
     QIcon graphIcon = QIcon(pixmap);
@@ -136,7 +139,8 @@ void MarkerInfoItem::updateColor(quint32 graphIdx)
 
 void MarkerInfoItem::updateLabel(quint32 graphIdx)
 {
-    _pGraphCombo->setItemText(_pGraphDataModel->convertToActiveGraphIndex(graphIdx) + 1, _pGraphDataModel->label(graphIdx));
+    _pGraphCombo->setItemText(_pGraphDataModel->convertToActiveGraphIndex(graphIdx) + 1,
+                              _pGraphDataModel->label(graphIdx));
 }
 
 void MarkerInfoItem::removeFromGraphList(const quint32 index)
@@ -147,12 +151,12 @@ void MarkerInfoItem::removeFromGraphList(const quint32 index)
     /* correct selected index when needed */
     if (currentSelectedIdx != -1)
     {
-        if ((qint32)index == currentSelectedIdx)
+        if ((qint32) index == currentSelectedIdx)
         {
             /* Current selected is removed */
             currentSelectedIdx = -1;
         }
-        else if ((qint32)index < currentSelectedIdx)
+        else if ((qint32) index < currentSelectedIdx)
         {
             /* Graph removed in front of our graph */
             currentSelectedIdx--;
@@ -166,19 +170,18 @@ void MarkerInfoItem::removeFromGraphList(const quint32 index)
     updateList();
 
     selectGraph(currentSelectedIdx);
-
 }
 
 void MarkerInfoItem::graphSelected(qint32 index)
 {
     if (index > 0)
     {
-         updateData();
+        updateData();
     }
     else
     {
-         _pGraphDataLabelLeft->setText("None");
-         _pGraphDataLabelRight->setText("");
+        _pGraphDataLabelLeft->setText("None");
+        _pGraphDataLabelRight->setText("");
     }
 }
 
@@ -191,7 +194,7 @@ void MarkerInfoItem::updateList()
 
     _pGraphCombo->addItem("None", -1);
 
-    foreach(quint16 idx, activeGraphList)
+    foreach (quint16 idx, activeGraphList)
     {
         _pGraphCombo->addItem(_pGraphDataModel->label(idx), QVariant(idx));
 
@@ -201,7 +204,7 @@ void MarkerInfoItem::updateList()
 
 void MarkerInfoItem::selectGraph(qint32 graphIndex)
 {
-    for(qint32 comboIdx = 0; comboIdx < _pGraphCombo->count(); comboIdx++)
+    for (qint32 comboIdx = 0; comboIdx < _pGraphCombo->count(); comboIdx++)
     {
         if (_pGraphCombo->itemData(comboIdx).toInt() == graphIndex)
         {
@@ -228,7 +231,8 @@ double MarkerInfoItem::calculateMarkerExpressionValue(quint32 expressionMask)
         return 0;
     }
 
-    const double valueDiff = pDataMap->findBegin(_pGuiModel->endMarkerPos(), false)->value - pDataMap->findBegin(_pGuiModel->startMarkerPos(), false)->value;
+    const double valueDiff = pDataMap->findBegin(_pGuiModel->endMarkerPos(), false)->value -
+                             pDataMap->findBegin(_pGuiModel->startMarkerPos(), false)->value;
     const double timeDiff = _pGuiModel->endMarkerPos() - _pGuiModel->startMarkerPos();
 
     QCPGraphDataContainer::const_iterator dataPoint;
@@ -307,7 +311,6 @@ double MarkerInfoItem::calculateMarkerExpressionValue(quint32 expressionMask)
     {
         result = 0;
     }
-
 
     return result;
 }

--- a/src/customwidgets/markerinfoitem.cpp
+++ b/src/customwidgets/markerinfoitem.cpp
@@ -68,7 +68,7 @@ void MarkerInfoItem::updateData()
         return;
     }
 
-    QSharedPointer<QCPGraphDataContainer> dataMap = _pGraphDataModel->dataMap(graphIdx);
+    QSharedPointer<const QCPGraphDataContainer> dataMap = _pGraphDataModel->dataMap(graphIdx);
 
     if (dataMap->isEmpty())
     {
@@ -221,7 +221,7 @@ double MarkerInfoItem::calculateMarkerExpressionValue(quint32 expressionMask)
         return 0;
     }
 
-    QSharedPointer<QCPGraphDataContainer> pDataMap = _pGraphDataModel->dataMap(graphIdx);
+    QSharedPointer<const QCPGraphDataContainer> pDataMap = _pGraphDataModel->dataMap(graphIdx);
 
     if (pDataMap->isEmpty())
     {

--- a/src/datahandling/graphdatahandler.cpp
+++ b/src/datahandling/graphdatahandler.cpp
@@ -65,7 +65,7 @@ QMuParser::ErrorType GraphDataHandler::expressionErrorType(qint32 exprIdx) const
     return _valueParsers[exprIdx].errorType();
 }
 
-ResultDoubleList GraphDataHandler::handleRegisterData(ResultDoubleList results)
+ResultDoubleList GraphDataHandler::handleRegisterData(const ResultDoubleList& results)
 {
     ResultDoubleList registerList;
 

--- a/src/datahandling/graphdatahandler.cpp
+++ b/src/datahandling/graphdatahandler.cpp
@@ -65,6 +65,12 @@ QMuParser::ErrorType GraphDataHandler::expressionErrorType(qint32 exprIdx) const
     return _valueParsers[exprIdx].errorType();
 }
 
+/*!
+ * \brief Evaluates each configured expression against the raw register results.
+ * \param results Raw register read results from the adapter (one entry per Modbus register).
+ * \return Expression-evaluated results (one entry per graph expression). Entries are marked
+ *         INVALID when expression evaluation fails; the input values are not passed through.
+ */
 ResultDoubleList GraphDataHandler::handleRegisterData(const ResultDoubleList& results)
 {
     ResultDoubleList registerList;

--- a/src/datahandling/graphdatahandler.cpp
+++ b/src/datahandling/graphdatahandler.cpp
@@ -65,7 +65,7 @@ QMuParser::ErrorType GraphDataHandler::expressionErrorType(qint32 exprIdx) const
     return _valueParsers[exprIdx].errorType();
 }
 
-void GraphDataHandler::handleRegisterData(ResultDoubleList results)
+ResultDoubleList GraphDataHandler::handleRegisterData(ResultDoubleList results)
 {
     ResultDoubleList registerList;
 
@@ -91,5 +91,5 @@ void GraphDataHandler::handleRegisterData(ResultDoubleList results)
         registerList.append(result);
     }
 
-    emit graphDataReady(registerList);
+    return registerList;
 }

--- a/src/datahandling/graphdatahandler.h
+++ b/src/datahandling/graphdatahandler.h
@@ -19,7 +19,7 @@ public:
     qint32 expressionErrorPos(qint32 exprIdx) const;
     QMuParser::ErrorType expressionErrorType(qint32 exprIdx) const;
 
-    ResultDoubleList handleRegisterData(ResultDoubleList results);
+    ResultDoubleList handleRegisterData(const ResultDoubleList& results);
 
 private:
     QList<quint16> _activeIndexList;

--- a/src/datahandling/graphdatahandler.h
+++ b/src/datahandling/graphdatahandler.h
@@ -8,9 +8,8 @@
 // Forward declaration
 class GraphDataModel;
 
-class GraphDataHandler : public QObject
+class GraphDataHandler
 {
-    Q_OBJECT
 public:
     GraphDataHandler() = default;
 
@@ -20,11 +19,7 @@ public:
     qint32 expressionErrorPos(qint32 exprIdx) const;
     QMuParser::ErrorType expressionErrorType(qint32 exprIdx) const;
 
-public slots:
-    void handleRegisterData(ResultDoubleList results);
-
-signals:
-    void graphDataReady(ResultDoubleList resultList);
+    ResultDoubleList handleRegisterData(ResultDoubleList results);
 
 private:
     QList<quint16> _activeIndexList;

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -59,7 +59,6 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     _pNotesDock = new NotesDock(_pNoteModel, _pGuiModel, this);
 
-    _pGraphDataHandler = new GraphDataHandler();
     _pAdapterPoll = new AdapterPoll(_pSettingsModel, this);
     connect(_pAdapterPoll, &AdapterPoll::registerDataReady, this, &MainWindow::onRegisterDataReady);
 
@@ -238,14 +237,6 @@ MainWindow::~MainWindow()
 {
     _pAdapterPoll->stopCommunication();
     disconnect(_pAdapterPoll, &AdapterPoll::registerDataReady, this, &MainWindow::onRegisterDataReady);
-
-    delete _pGraphDataHandler;
-
-    delete _pGraphView;
-    delete _pGraphShowHide;
-    delete _pMostRecentMenu;
-    delete _pDataFileHandler;
-    delete _pStatusBar;
 
     delete _pUi;
 }
@@ -481,7 +472,7 @@ void MainWindow::startScope()
         clearData();
 
         QList<DataPoint> registerList;
-        _pGraphDataHandler->setupExpressions(_pGraphDataModel, registerList);
+        _graphDataHandler.setupExpressions(_pGraphDataModel, registerList);
 
         _pAdapterPoll->startCommunication(registerList);
         _pCommunicationStats->start();
@@ -834,9 +825,9 @@ void MainWindow::updateDataFileNotes()
     }
 }
 
-void MainWindow::onRegisterDataReady(ResultDoubleList results)
+void MainWindow::onRegisterDataReady(const ResultDoubleList& results)
 {
-    ResultDoubleList processed = _pGraphDataHandler->handleRegisterData(results);
+    ResultDoubleList processed = _graphDataHandler.handleRegisterData(results);
     _pGraphView->plotResults(processed);
     _pLegend->addLastReceivedDataToLegend(processed);
     _pCommunicationStats->updateCommunicationStats(processed);

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -61,7 +61,7 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     _pGraphDataHandler = new GraphDataHandler();
     _pAdapterPoll = new AdapterPoll(_pSettingsModel, this);
-    connect(_pAdapterPoll, &AdapterPoll::registerDataReady, _pGraphDataHandler, &GraphDataHandler::handleRegisterData);
+    connect(_pAdapterPoll, &AdapterPoll::registerDataReady, this, &MainWindow::onRegisterDataReady);
 
     _pGraphView = new GraphView(_pGuiModel, _pSettingsModel, _pGraphDataModel, _pNoteModel, _pUi->customPlot, this);
     _pDataFileHandler =
@@ -214,10 +214,6 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     handleGraphsCountChanged();
 
-    connect(_pGraphDataHandler, &GraphDataHandler::graphDataReady, _pGraphView, &GraphView::plotResults);
-    connect(_pGraphDataHandler, &GraphDataHandler::graphDataReady, _pLegend, &Legend::addLastReceivedDataToLegend);
-    connect(_pGraphDataHandler, &GraphDataHandler::graphDataReady, _pCommunicationStats,
-            &CommunicationStats::updateCommunicationStats);
 
     handleCommandLineArguments(cmdArguments);
 
@@ -833,6 +829,14 @@ void MainWindow::updateDataFileNotes()
             _pDataFileHandler->updateNoteLines();
         }
     }
+}
+
+void MainWindow::onRegisterDataReady(ResultDoubleList results)
+{
+    ResultDoubleList processed = _pGraphDataHandler->handleRegisterData(results);
+    _pGraphView->plotResults(processed);
+    _pLegend->addLastReceivedDataToLegend(processed);
+    _pCommunicationStats->updateCommunicationStats(processed);
 }
 
 void MainWindow::showVersionUpdate(UpdateNotify::UpdateState result)

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -200,7 +200,8 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     /* Trigger update check */
     _pUi->actionUpdateAvailable->setVisible(false);
-    _pUpdateNotify = new UpdateNotify(new VersionDownloader(this), Util::currentVersion(), this);
+    auto* pVersionDownloader = new VersionDownloader(this);
+    _pUpdateNotify = new UpdateNotify(pVersionDownloader, Util::currentVersion(), this);
     connect(_pUpdateNotify, &UpdateNotify::updateCheckResult, this, &MainWindow::showVersionUpdate);
 
 #ifndef DEBUG

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -200,7 +200,7 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     /* Trigger update check */
     _pUi->actionUpdateAvailable->setVisible(false);
-    _pUpdateNotify = new UpdateNotify(new VersionDownloader(), Util::currentVersion(), this);
+    _pUpdateNotify = new UpdateNotify(new VersionDownloader(this), Util::currentVersion(), this);
     connect(_pUpdateNotify, &UpdateNotify::updateCheckResult, this, &MainWindow::showVersionUpdate);
 
 #ifndef DEBUG

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -60,15 +60,15 @@ MainWindow::MainWindow(QStringList cmdArguments,
     _pNotesDock = new NotesDock(_pNoteModel, _pGuiModel, this);
 
     _pGraphDataHandler = new GraphDataHandler();
-    _pAdapterPoll = new AdapterPoll(_pSettingsModel);
+    _pAdapterPoll = new AdapterPoll(_pSettingsModel, this);
     connect(_pAdapterPoll, &AdapterPoll::registerDataReady, _pGraphDataHandler, &GraphDataHandler::handleRegisterData);
 
     _pGraphView = new GraphView(_pGuiModel, _pSettingsModel, _pGraphDataModel, _pNoteModel, _pUi->customPlot, this);
     _pDataFileHandler =
       new DataFileHandler(_pGuiModel, _pGraphDataModel, _pNoteModel, _pSettingsModel, _pDataParserModel, this);
-    _pProjectFileHandler = new ProjectFileHandler(_pGuiModel, _pSettingsModel, _pGraphDataModel);
-    _pExpressionStatus = new ExpressionStatus(_pGraphDataModel, pSettingsModel);
-    _pCommunicationStats = new CommunicationStats(_pGraphDataModel);
+    _pProjectFileHandler = new ProjectFileHandler(_pGuiModel, _pSettingsModel, _pGraphDataModel, this);
+    _pExpressionStatus = new ExpressionStatus(_pGraphDataModel, pSettingsModel, this);
+    _pCommunicationStats = new CommunicationStats(_pGraphDataModel, 50, this);
 
     _pLegend = _pUi->legend;
     _pLegend->setModels(_pGuiModel, _pGraphDataModel);
@@ -201,7 +201,7 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     /* Trigger update check */
     _pUi->actionUpdateAvailable->setVisible(false);
-    _pUpdateNotify = new UpdateNotify(new VersionDownloader(), Util::currentVersion());
+    _pUpdateNotify = new UpdateNotify(new VersionDownloader(), Util::currentVersion(), this);
     connect(_pUpdateNotify, &UpdateNotify::updateCheckResult, this, &MainWindow::showVersionUpdate);
 
 #ifndef DEBUG
@@ -240,16 +240,13 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
 MainWindow::~MainWindow()
 {
+    delete _pGraphDataHandler;
+
     delete _pGraphView;
-    delete _pAdapterPoll;
     delete _pGraphShowHide;
     delete _pMostRecentMenu;
     delete _pDataFileHandler;
-    delete _pProjectFileHandler;
-    delete _pExpressionStatus;
     delete _pStatusBar;
-
-    delete _pUpdateNotify;
 
     delete _pUi;
 }

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -236,6 +236,9 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
 MainWindow::~MainWindow()
 {
+    _pAdapterPoll->stopCommunication();
+    disconnect(_pAdapterPoll, &AdapterPoll::registerDataReady, this, &MainWindow::onRegisterDataReady);
+
     delete _pGraphDataHandler;
 
     delete _pGraphView;

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -213,7 +213,6 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     handleGraphsCountChanged();
 
-
     handleCommandLineArguments(cmdArguments);
 
     _pAdapterPoll->initAdapter();

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include "util/recentfilemodule.h"
+#include "util/result.h"
 #include "util/updatenotify.h"
 
 #include <QButtonGroup>
@@ -101,6 +102,7 @@ private slots:
     void updateDataFileNotes();
 
     void showVersionUpdate(UpdateNotify::UpdateState result);
+    void onRegisterDataReady(ResultDoubleList results);
 
 private:
     void setAxisToAuto();

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -102,7 +102,7 @@ private slots:
     void updateDataFileNotes();
 
     void showVersionUpdate(UpdateNotify::UpdateState result);
-    void onRegisterDataReady(ResultDoubleList results);
+    void onRegisterDataReady(const ResultDoubleList& results);
 
 private:
     void setAxisToAuto();
@@ -122,7 +122,7 @@ private:
     DataParserModel* _pDataParserModel;
 
     UpdateNotify* _pUpdateNotify;
-    GraphDataHandler* _pGraphDataHandler;
+    GraphDataHandler _graphDataHandler;
     ExpressionStatus* _pExpressionStatus;
     CommunicationStats* _pCommunicationStats;
 

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -1,6 +1,7 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
+#include "datahandling/graphdatahandler.h"
 #include "util/recentfilemodule.h"
 #include "util/result.h"
 #include "util/updatenotify.h"
@@ -16,7 +17,6 @@ class MainWindow;
 
 // Forward declaration
 class AdapterPoll;
-class GraphDataHandler;
 class QCustomPlot;
 class GraphDataModel;
 class NoteModel;

--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -252,7 +252,8 @@ void GraphView::updateGraphs()
             // Set data to zero when needed
             if (pMap->size() != maxSampleCount)
             {
-                const QSharedPointer<const QCPGraphDataContainer> pReferenceMap = _pGraphDataModel->dataMap(maxSampleIdx);
+                const QSharedPointer<const QCPGraphDataContainer> pReferenceMap =
+                  _pGraphDataModel->dataMap(maxSampleIdx);
                 pMap->clear();
 
                 // Add zero value for every key (x-coordinate)

--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -188,17 +188,17 @@ void GraphView::clearGraph(const quint32 graphIdx)
         else if (activeGraphList.size() == 1)
         {
             /* Only one graph active: clear all data */
-            _pGraphDataModel->dataMap(graphIdx)->clear();
+            _pGraphDataModel->mutableDataMap(graphIdx)->clear();
 
             _pPlot->replot();
         }
         else
         {
             /* Several active graph, keep time data but clear data */
-            QCPGraphDataContainer::iterator it = _pGraphDataModel->dataMap(graphIdx)->begin();
+            QCPGraphDataContainer::iterator it = _pGraphDataModel->mutableDataMap(graphIdx)->begin();
 
             /* Clear all values, keep keys */
-            while (it != _pGraphDataModel->dataMap(graphIdx)->end())
+            while (it != _pGraphDataModel->mutableDataMap(graphIdx)->end())
             {
                 it->value = 0u;
                 it++;
@@ -247,12 +247,12 @@ void GraphView::updateGraphs()
 
             connect(pGraph, QOverload<bool>::of(&QCPGraph::selectionChanged), this, &GraphView::handleSelectionChanged);
 
-            QSharedPointer<QCPGraphDataContainer> pMap = _pGraphDataModel->dataMap(graphIdx);
+            QSharedPointer<QCPGraphDataContainer> pMap = _pGraphDataModel->mutableDataMap(graphIdx);
 
             // Set data to zero when needed
             if (pMap->size() != maxSampleCount)
             {
-                const QSharedPointer<QCPGraphDataContainer> pReferenceMap = _pGraphDataModel->dataMap(maxSampleIdx);
+                const QSharedPointer<const QCPGraphDataContainer> pReferenceMap = _pGraphDataModel->dataMap(maxSampleIdx);
                 pMap->clear();
 
                 // Add zero value for every key (x-coordinate)

--- a/src/importexport/projectfilehandler.cpp
+++ b/src/importexport/projectfilehandler.cpp
@@ -20,8 +20,9 @@
 
 ProjectFileHandler::ProjectFileHandler(GuiModel* pGuiModel,
                                        SettingsModel* pSettingsModel,
-                                       GraphDataModel* pGraphDataModel)
-    : QObject(nullptr)
+                                       GraphDataModel* pGraphDataModel,
+                                       QObject* parent)
+    : QObject(parent)
 {
     _pGuiModel = pGuiModel;
     _pSettingsModel = pSettingsModel;

--- a/src/importexport/projectfilehandler.h
+++ b/src/importexport/projectfilehandler.h
@@ -14,7 +14,10 @@ class ProjectFileHandler : public QObject
 {
     Q_OBJECT
 public:
-    explicit ProjectFileHandler(GuiModel* pGuiModel, SettingsModel* pSettingsModel, GraphDataModel* pGraphDataModel, QObject* parent = nullptr);
+    explicit ProjectFileHandler(GuiModel* pGuiModel,
+                                SettingsModel* pSettingsModel,
+                                GraphDataModel* pGraphDataModel,
+                                QObject* parent = nullptr);
 
     void openProjectFile(QString projectFilePath);
 

--- a/src/importexport/projectfilehandler.h
+++ b/src/importexport/projectfilehandler.h
@@ -14,7 +14,7 @@ class ProjectFileHandler : public QObject
 {
     Q_OBJECT
 public:
-    explicit ProjectFileHandler(GuiModel* pGuiModel, SettingsModel* pSettingsModel, GraphDataModel* pGraphDataModel);
+    explicit ProjectFileHandler(GuiModel* pGuiModel, SettingsModel* pSettingsModel, GraphDataModel* pGraphDataModel, QObject* parent = nullptr);
 
     void openProjectFile(QString projectFilePath);
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -16,14 +16,14 @@
 MainApp::MainApp(QStringList cmdArguments, QObject* parent) : QObject(parent)
 {
     /* Setup diagnostic model and logging before all the rest */
-    _pDiagnosticModel = new DiagnosticModel();
+    _pDiagnosticModel = new DiagnosticModel(this);
     ScopeLogging::Logger().initLogging(_pDiagnosticModel);
 
-    _pGuiModel = new GuiModel();
-    _pSettingsModel = new SettingsModel();
-    _pGraphDataModel = new GraphDataModel();
-    _pNoteModel = new NoteModel();
-    _pDataParserModel = new DataParserModel();
+    _pGuiModel = new GuiModel(this);
+    _pSettingsModel = new SettingsModel(this);
+    _pGraphDataModel = new GraphDataModel(this);
+    _pNoteModel = new NoteModel(this);
+    _pDataParserModel = new DataParserModel(this);
 
     _pMainWin = new MainWindow(cmdArguments, _pGuiModel, _pSettingsModel, _pGraphDataModel, _pNoteModel,
                                _pDiagnosticModel, _pDataParserModel);
@@ -43,13 +43,6 @@ MainApp::MainApp(QStringList cmdArguments, QObject* parent) : QObject(parent)
 MainApp::~MainApp()
 {
     delete _pMainWin;
-
-    delete _pDataParserModel;
-    delete _pDiagnosticModel;
-    delete _pNoteModel;
-    delete _pGraphDataModel;
-    delete _pSettingsModel;
-    delete _pGuiModel;
 }
 
 void MainApp::logInitialInfo()

--- a/src/models/graphdata.cpp
+++ b/src/models/graphdata.cpp
@@ -45,7 +45,7 @@ QString GraphData::label() const
     return _label;
 }
 
-void GraphData::setLabel(const QString &label)
+void GraphData::setLabel(const QString& label)
 {
     /* Remove separator char (used in export) from label */
     QString cleanedLabel = QString(label).remove(Util::separatorCharacter());
@@ -58,7 +58,7 @@ QColor GraphData::color() const
     return _color;
 }
 
-void GraphData::setColor(const QColor &color)
+void GraphData::setColor(const QColor& color)
 {
     _color = color;
 }

--- a/src/models/graphdata.cpp
+++ b/src/models/graphdata.cpp
@@ -15,10 +15,7 @@ GraphData::GraphData()
     _pDataMap = QSharedPointer<QCPGraphDataContainer>(new QCPGraphDataContainer);
 }
 
-GraphData::~GraphData()
-{
-    _pDataMap.clear();
-}
+GraphData::~GraphData() = default;
 
 GraphData::valueAxis_t GraphData::valueAxis() const
 {

--- a/src/models/graphdata.cpp
+++ b/src/models/graphdata.cpp
@@ -102,7 +102,12 @@ void GraphData::setExpressionState(GraphData::ExpressionState status)
     _expressionState = status;
 }
 
-QSharedPointer<QCPGraphDataContainer> GraphData::dataMap()
+QSharedPointer<const QCPGraphDataContainer> GraphData::dataMap() const
+{
+    return _pDataMap;
+}
+
+QSharedPointer<QCPGraphDataContainer> GraphData::mutableDataMap()
 {
     return _pDataMap;
 }

--- a/src/models/graphdata.h
+++ b/src/models/graphdata.h
@@ -1,9 +1,9 @@
 #ifndef GRAPHDATA_H
 #define GRAPHDATA_H
 
-#include <QtGlobal>
-#include <QColor>
 #include "qcustomplot/qcustomplot.h"
+#include <QColor>
+#include <QtGlobal>
 
 class GraphData
 {
@@ -34,10 +34,10 @@ public:
     void setVisible(bool bVisible);
 
     QString label() const;
-    void setLabel(const QString &label);
+    void setLabel(const QString& label);
 
     QColor color() const;
-    void setColor(const QColor &color);
+    void setColor(const QColor& color);
 
     bool isActive() const;
     void setActive(bool bActive);
@@ -53,7 +53,6 @@ public:
     QSharedPointer<QCPGraphDataContainer> mutableDataMap();
 
 private:
-
     valueAxis_t _valueAxis;
     bool _bVisible;
     QString _label;
@@ -64,7 +63,6 @@ private:
     ExpressionState _expressionState;
 
     QSharedPointer<QCPGraphDataContainer> _pDataMap;
-
 };
 
 #endif // GRAPHDATA_H

--- a/src/models/graphdata.h
+++ b/src/models/graphdata.h
@@ -49,7 +49,8 @@ public:
     void setExpressionState(ExpressionState status);
     bool isExpressionValid() const;
 
-    QSharedPointer<QCPGraphDataContainer> dataMap();
+    QSharedPointer<const QCPGraphDataContainer> dataMap() const;
+    QSharedPointer<QCPGraphDataContainer> mutableDataMap();
 
 private:
 

--- a/src/models/graphdatamodel.cpp
+++ b/src/models/graphdatamodel.cpp
@@ -7,8 +7,7 @@
 
 const QColor GraphDataModel::lightRed = QColor(240, 128, 128); // #f08080
 
-GraphDataModel::GraphDataModel(QObject *parent)
-    : QAbstractTableModel(parent), _selectedGraphIdx(-1)
+GraphDataModel::GraphDataModel(QObject* parent) : QAbstractTableModel(parent), _selectedGraphIdx(-1)
 {
     _graphData.clear();
     _startTime = 0;
@@ -28,17 +27,17 @@ GraphDataModel::GraphDataModel(QObject *parent)
     connect(this, &GraphDataModel::removed, this, &GraphDataModel::modelCompleteDataChanged);
 }
 
-int GraphDataModel::rowCount(const QModelIndex & /*parent*/) const
+int GraphDataModel::rowCount(const QModelIndex& /*parent*/) const
 {
     return size();
 }
 
-int GraphDataModel::columnCount(const QModelIndex & /*parent*/) const
+int GraphDataModel::columnCount(const QModelIndex& /*parent*/) const
 {
     return column::COUNT;
 }
 
-QVariant GraphDataModel::data(const QModelIndex &index, int role) const
+QVariant GraphDataModel::data(const QModelIndex& index, int role) const
 {
     switch (index.column())
     {
@@ -139,15 +138,14 @@ QVariant GraphDataModel::headerData(int section, Qt::Orientation orientation, in
         }
         else
         {
-            //Can't happen because it is hidden
+            // Can't happen because it is hidden
         }
     }
 
     return QVariant();
 }
 
-
-bool GraphDataModel::setData(const QModelIndex & index, const QVariant & value, int role)
+bool GraphDataModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
     bool bRet = true;
 
@@ -198,10 +196,7 @@ bool GraphDataModel::setData(const QModelIndex & index, const QVariant & value, 
             bool bSuccess = false;
             const quint8 newValueAxis = static_cast<quint8>(value.toUInt(&bSuccess));
 
-            if (
-                    (bSuccess)
-                    && (newValueAxis < GraphData::VALUE_AXIS_CNT)
-                )
+            if ((bSuccess) && (newValueAxis < GraphData::VALUE_AXIS_CNT))
             {
                 setValueAxis(index.row(), static_cast<GraphData::valueAxis_t>(newValueAxis));
             }
@@ -215,7 +210,6 @@ bool GraphDataModel::setData(const QModelIndex & index, const QVariant & value, 
         break;
     default:
         break;
-
     }
 
     // Notify view(s) of change
@@ -224,7 +218,7 @@ bool GraphDataModel::setData(const QModelIndex & index, const QVariant & value, 
     return bRet;
 }
 
-Qt::ItemFlags GraphDataModel::flags(const QModelIndex & index) const
+Qt::ItemFlags GraphDataModel::flags(const QModelIndex& index) const
 {
     Qt::ItemFlags itemFlags = Qt::NoItemFlags;
 
@@ -242,7 +236,7 @@ Qt::ItemFlags GraphDataModel::flags(const QModelIndex & index) const
     if (index.column() == column::ACTIVE)
     {
         // checkable
-        itemFlags |= Qt::ItemIsSelectable |  Qt::ItemIsUserCheckable;
+        itemFlags |= Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
     }
     else if (index.column() == column::COLOR)
     {
@@ -250,7 +244,7 @@ Qt::ItemFlags GraphDataModel::flags(const QModelIndex & index) const
     }
     else
     {
-        itemFlags |= Qt::ItemIsSelectable |  Qt::ItemIsEditable;
+        itemFlags |= Qt::ItemIsSelectable | Qt::ItemIsEditable;
     }
 
     return itemFlags;
@@ -261,7 +255,7 @@ Qt::DropActions GraphDataModel::supportedDropActions() const
     return Qt::MoveAction;
 }
 
-bool GraphDataModel::removeRows(int row, int count, const QModelIndex & parent)
+bool GraphDataModel::removeRows(int row, int count, const QModelIndex& parent)
 {
     Q_UNUSED(parent);
     Q_UNUSED(count);
@@ -271,12 +265,9 @@ bool GraphDataModel::removeRows(int row, int count, const QModelIndex & parent)
     return true;
 }
 
-bool GraphDataModel::insertRows(int row, int count, const QModelIndex &parent)
+bool GraphDataModel::insertRows(int row, int count, const QModelIndex& parent)
 {
-    if (
-        (count != 1)
-        || (row != size())
-        )
+    if ((count != 1) || (row != size()))
     {
         qDebug() << "RegisterModel: Not supported";
     }
@@ -290,9 +281,9 @@ bool GraphDataModel::insertRows(int row, int count, const QModelIndex &parent)
     return true;
 }
 
-QMimeData *GraphDataModel::mimeData(const QModelIndexList &indexes) const
+QMimeData* GraphDataModel::mimeData(const QModelIndexList& indexes) const
 {
-    QMimeData *data = QAbstractTableModel::mimeData(indexes);
+    QMimeData* data = QAbstractTableModel::mimeData(indexes);
 
     if (data)
     {
@@ -302,7 +293,8 @@ QMimeData *GraphDataModel::mimeData(const QModelIndexList &indexes) const
     return data;
 }
 
-bool GraphDataModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent)
+bool GraphDataModel::dropMimeData(
+  const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent)
 {
     Q_UNUSED(parent);
     Q_UNUSED(column);
@@ -394,7 +386,6 @@ QSharedPointer<QCPGraphDataContainer> GraphDataModel::mutableDataMap(quint32 ind
     return _graphData[index].mutableDataMap();
 }
 
-
 qint64 GraphDataModel::communicationStartTime()
 {
     return _startTime;
@@ -425,10 +416,7 @@ void GraphDataModel::setCommunicationEndTime(qint64 endTime)
 
 void GraphDataModel::setCommunicationStats(quint32 successCount, quint32 errorCount)
 {
-    if (
-        (_successCount != successCount)
-        || (_errorCount != errorCount)
-        )
+    if ((_successCount != successCount) || (_errorCount != errorCount))
     {
         _successCount = successCount;
         _errorCount = errorCount;
@@ -465,8 +453,8 @@ void GraphDataModel::setValueAxis(quint32 index, GraphData::valueAxis_t axis)
 {
     if (_graphData[index].valueAxis() != axis)
     {
-         _graphData[index].setValueAxis(axis);
-         emit valueAxisChanged(index);
+        _graphData[index].setValueAxis(axis);
+        emit valueAxisChanged(index);
     }
 }
 
@@ -484,21 +472,21 @@ void GraphDataModel::setVisible(quint32 index, bool bVisible)
     }
 }
 
-void GraphDataModel::setLabel(quint32 index, const QString &label)
+void GraphDataModel::setLabel(quint32 index, const QString& label)
 {
     if (_graphData[index].label() != label)
     {
-         _graphData[index].setLabel(label);
-         emit labelChanged(index);
+        _graphData[index].setLabel(label);
+        emit labelChanged(index);
     }
 }
 
-void GraphDataModel::setColor(quint32 index, const QColor &color)
+void GraphDataModel::setColor(quint32 index, const QColor& color)
 {
     if (_graphData[index].color() != color)
     {
-         _graphData[index].setColor(color);
-         emit colorChanged(index);
+        _graphData[index].setColor(color);
+        emit colorChanged(index);
     }
 }
 
@@ -529,8 +517,8 @@ void GraphDataModel::setExpression(quint32 index, QString expression)
 {
     if (_graphData[index].expression() != expression)
     {
-         _graphData[index].setExpression(expression);
-         emit expressionChanged(index);
+        _graphData[index].setExpression(expression);
+        emit expressionChanged(index);
     }
 }
 
@@ -586,7 +574,7 @@ void GraphDataModel::add()
 
 void GraphDataModel::add(QList<QString> labelList)
 {
-    foreach(QString label, labelList)
+    foreach (QString label, labelList)
     {
         add();
         setLabel(_graphData.size() - 1, label);
@@ -626,12 +614,12 @@ void GraphDataModel::clear()
 }
 
 // Get list of active graph indexes
-void GraphDataModel::activeGraphIndexList(QList<quint16> * pList)
+void GraphDataModel::activeGraphIndexList(QList<quint16>* pList)
 {
     // Clear list
     pList->clear();
 
-    foreach(quint32 idx, _activeGraphList)
+    foreach (quint32 idx, _activeGraphList)
     {
         pList->append(idx);
     }
@@ -721,7 +709,7 @@ void GraphDataModel::removeFromModel(qint32 row)
 void GraphDataModel::moveRow(int sourceRow, int destRow)
 {
     int newRow = destRow;
-    if(newRow == -1 || newRow >= rowCount())
+    if (newRow == -1 || newRow >= rowCount())
     {
         newRow = rowCount() - 1;
     }

--- a/src/models/graphdatamodel.cpp
+++ b/src/models/graphdatamodel.cpp
@@ -384,9 +384,14 @@ QString GraphDataModel::simplifiedExpression(quint32 index) const
     return _graphData[index].expression().simplified();
 }
 
-QSharedPointer<QCPGraphDataContainer> GraphDataModel::dataMap(quint32 index)
+QSharedPointer<const QCPGraphDataContainer> GraphDataModel::dataMap(quint32 index) const
 {
     return _graphData[index].dataMap();
+}
+
+QSharedPointer<QCPGraphDataContainer> GraphDataModel::mutableDataMap(quint32 index)
+{
+    return _graphData[index].mutableDataMap();
 }
 
 
@@ -508,7 +513,7 @@ void GraphDataModel::setActive(quint32 index, bool bActive)
         // When deactivated, clear data
         if (!bActive)
         {
-            _graphData[index].dataMap()->clear();
+            _graphData[index].mutableDataMap()->clear();
         }
         else
         {

--- a/src/models/graphdatamodel.h
+++ b/src/models/graphdatamodel.h
@@ -1,9 +1,9 @@
 #ifndef GRAPHDATAMODEL_H
 #define GRAPHDATAMODEL_H
 
-#include <QObject>
 #include <QAbstractTableModel>
 #include <QList>
+#include <QObject>
 
 #include "models/graphdata.h"
 
@@ -11,8 +11,8 @@ class GraphDataModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
-
-    enum column {
+    enum column
+    {
         COLOR = 0,
         ACTIVE,
         TEXT,
@@ -24,22 +24,22 @@ public:
 
     static const QColor lightRed;
 
-    explicit GraphDataModel(QObject *parent = nullptr);
+    explicit GraphDataModel(QObject* parent = nullptr);
 
     /* Functions for QTableView (model) */
-    int rowCount(const QModelIndex &parent = QModelIndex()) const ;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const;
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
-    bool setData(const QModelIndex & index, const QVariant & value, int role);
-    Qt::ItemFlags flags(const QModelIndex & index) const;
+    bool setData(const QModelIndex& index, const QVariant& value, int role);
+    Qt::ItemFlags flags(const QModelIndex& index) const;
     Qt::DropActions supportedDropActions() const;
 
-    bool removeRows(int row, int count, const QModelIndex &parent);
-    bool insertRows(int row, int count, const QModelIndex &parent);
+    bool removeRows(int row, int count, const QModelIndex& parent);
+    bool insertRows(int row, int count, const QModelIndex& parent);
 
-    QMimeData* mimeData(const QModelIndexList &indexes) const;
-    bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent);
+    QMimeData* mimeData(const QModelIndexList& indexes) const;
+    bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent);
 
     /* Functions for other classes */
     qint32 size() const;
@@ -67,8 +67,8 @@ public:
 
     void setValueAxis(quint32 index, GraphData::valueAxis_t axis);
     void setVisible(quint32 index, bool bVisible);
-    void setLabel(quint32 index, const QString &label);
-    void setColor(quint32 index, const QColor &color);
+    void setLabel(quint32 index, const QString& label);
+    void setColor(quint32 index, const QColor& color);
     void setActive(quint32 index, bool bActive);
     void setExpression(quint32 index, QString expression);
     void setExpressionState(quint32 index, GraphData::ExpressionState status);
@@ -88,7 +88,7 @@ public:
     void removeRegister(qint32 idx);
     void clear();
 
-    void activeGraphIndexList(QList<quint16> * pList);
+    void activeGraphIndexList(QList<quint16>* pList);
 
     qint32 convertToActiveGraphIndex(quint32 graphIdx);
     qint32 convertToGraphIndex(quint32 activeIdx);

--- a/src/models/graphdatamodel.h
+++ b/src/models/graphdatamodel.h
@@ -55,7 +55,8 @@ public:
     bool isExpressionValid(quint32 index) const;
     qint32 selectedGraph() const;
     QString simplifiedExpression(quint32 index) const;
-    QSharedPointer<QCPGraphDataContainer> dataMap(quint32 index);
+    QSharedPointer<const QCPGraphDataContainer> dataMap(quint32 index) const;
+    QSharedPointer<QCPGraphDataContainer> mutableDataMap(quint32 index);
 
     qint64 communicationStartTime();
     qint64 communicationEndTime();

--- a/src/util/expressionchecker.cpp
+++ b/src/util/expressionchecker.cpp
@@ -3,7 +3,6 @@
 
 ExpressionChecker::ExpressionChecker(QObject* parent) : QObject(parent)
 {
-    connect(&_graphDataHandler, &GraphDataHandler::graphDataReady, this, &ExpressionChecker::handleDataReady);
 }
 
 void ExpressionChecker::setExpression(QString expr)
@@ -66,7 +65,7 @@ bool ExpressionChecker::checkForDevices(QList<deviceId_t> const& deviceIdList)
 
 void ExpressionChecker::checkWithValues(ResultDoubleList results)
 {
-    _graphDataHandler.handleRegisterData(results);
+    handleDataReady(_graphDataHandler.handleRegisterData(results));
 }
 
 bool ExpressionChecker::isValid()

--- a/src/util/expressionchecker.h
+++ b/src/util/expressionchecker.h
@@ -30,10 +30,8 @@ public:
 signals:
     void resultsReady(bool valid);
 
-private slots:
-    void handleDataReady(ResultDoubleList resultList);
-
 private:
+    void handleDataReady(ResultDoubleList resultList);
 
     GraphDataModel _localGraphDataModel;
     GraphDataHandler _graphDataHandler;

--- a/src/util/expressionchecker.h
+++ b/src/util/expressionchecker.h
@@ -9,8 +9,7 @@ class ExpressionChecker : public QObject
 {
     Q_OBJECT
 public:
-
-    explicit ExpressionChecker(QObject *parent = nullptr);
+    explicit ExpressionChecker(QObject* parent = nullptr);
 
     void setExpression(QString expr);
 

--- a/tests/datahandling/tst_graphdatahandler.cpp
+++ b/tests/datahandling/tst_graphdatahandler.cpp
@@ -6,7 +6,6 @@
 #include "models/graphdatamodel.h"
 #include "models/settingsmodel.h"
 
-#include <QSignalSpy>
 #include <QTest>
 
 Q_DECLARE_METATYPE(Result<quint16>);
@@ -139,12 +138,9 @@ void TestGraphDataHandler::graphData()
     CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
 
     auto regResults = ResultDoubleList() << ResultDouble(1, State::SUCCESS) << ResultDouble(2, State::SUCCESS);
+    auto expected = ResultDoubleList() << ResultDouble(3, State::SUCCESS);
 
-    auto resultList = ResultDoubleList() << ResultDouble(3, State::SUCCESS);
-
-    QList<QVariant> rawRegData;
-    doHandleRegisterData(regResults, rawRegData);
-    CommunicationHelpers::verifyReceivedDataSignal(rawRegData, resultList);
+    QCOMPARE(doHandleRegisterData(regResults), expected);
 }
 
 void TestGraphDataHandler::graphDataTwice()
@@ -153,30 +149,17 @@ void TestGraphDataHandler::graphDataTwice()
 
     CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
 
-    auto regResults_1 = ResultDoubleList() << ResultDouble(1, State::SUCCESS) << ResultDouble(2, State::SUCCESS);
-
-    auto regResults_2 = ResultDoubleList() << ResultDouble(3, State::SUCCESS) << ResultDouble(4, State::SUCCESS);
-
-    QList<QVariant> rawRegData;
     GraphDataHandler dataHandler;
-
     QList<DataPoint> registerList;
     dataHandler.setupExpressions(_pGraphDataModel, registerList);
 
-    QSignalSpy spyDataReady(&dataHandler, &GraphDataHandler::graphDataReady);
+    auto regResults_1 = ResultDoubleList() << ResultDouble(1, State::SUCCESS) << ResultDouble(2, State::SUCCESS);
+    auto result_1 = dataHandler.handleRegisterData(regResults_1);
+    QCOMPARE(result_1, ResultDoubleList() << ResultDouble(3, State::SUCCESS));
 
-    dataHandler.handleRegisterData(regResults_1);
-    dataHandler.handleRegisterData(regResults_2);
-
-    QCOMPARE(spyDataReady.count(), 2);
-
-    auto resultList = ResultDoubleList() << ResultDouble(3, State::SUCCESS);
-    rawRegData = spyDataReady.takeFirst();
-    CommunicationHelpers::verifyReceivedDataSignal(rawRegData, resultList);
-
-    resultList = ResultDoubleList() << ResultDouble(7, State::SUCCESS);
-    rawRegData = spyDataReady.takeFirst();
-    CommunicationHelpers::verifyReceivedDataSignal(rawRegData, resultList);
+    auto regResults_2 = ResultDoubleList() << ResultDouble(3, State::SUCCESS) << ResultDouble(4, State::SUCCESS);
+    auto result_2 = dataHandler.handleRegisterData(regResults_2);
+    QCOMPARE(result_2, ResultDoubleList() << ResultDouble(7, State::SUCCESS));
 }
 
 void TestGraphDataHandler::graphData_fail()
@@ -187,25 +170,17 @@ void TestGraphDataHandler::graphData_fail()
     CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
 
     auto regResults = ResultDoubleList() << ResultDouble(1, State::SUCCESS) << ResultDouble(0, State::INVALID);
+    auto expected = ResultDoubleList() << ResultDouble(0, State::INVALID) << ResultDouble(1, State::SUCCESS);
 
-    auto resultList = ResultDoubleList() << ResultDouble(0, State::INVALID) << ResultDouble(1, State::SUCCESS);
-
-    QList<QVariant> rawRegData;
-    doHandleRegisterData(regResults, rawRegData);
-    CommunicationHelpers::verifyReceivedDataSignal(rawRegData, resultList);
+    QCOMPARE(doHandleRegisterData(regResults), expected);
 }
 
-void TestGraphDataHandler::doHandleRegisterData(ResultDoubleList& modbusResults, QList<QVariant>& actRawData)
+ResultDoubleList TestGraphDataHandler::doHandleRegisterData(ResultDoubleList modbusResults)
 {
     GraphDataHandler dataHandler;
     QList<DataPoint> registerList;
     dataHandler.setupExpressions(_pGraphDataModel, registerList);
-
-    QSignalSpy spyDataReady(&dataHandler, &GraphDataHandler::graphDataReady);
-    dataHandler.handleRegisterData(modbusResults);
-
-    QCOMPARE(spyDataReady.count(), 1);
-    actRawData = spyDataReady.takeFirst();
+    return dataHandler.handleRegisterData(modbusResults);
 }
 
 QTEST_GUILESS_MAIN(TestGraphDataHandler)

--- a/tests/datahandling/tst_graphdatahandler.h
+++ b/tests/datahandling/tst_graphdatahandler.h
@@ -10,7 +10,7 @@
 class GraphDataModel;
 class SettingsModel;
 
-class TestGraphDataHandler: public QObject
+class TestGraphDataHandler : public QObject
 {
     Q_OBJECT
 
@@ -31,12 +31,10 @@ private slots:
     void graphData_fail();
 
 private:
-
     ResultDoubleList doHandleRegisterData(ResultDoubleList modbusResults);
 
     SettingsModel* _pSettingsModel;
     GraphDataModel* _pGraphDataModel;
-
 };
 
 #endif /* TEST_GRAPHDATAHANDLER_H__ */

--- a/tests/datahandling/tst_graphdatahandler.h
+++ b/tests/datahandling/tst_graphdatahandler.h
@@ -32,7 +32,7 @@ private slots:
 
 private:
 
-    void doHandleRegisterData(ResultDoubleList& modbusResults, QList<QVariant> &actRawData);
+    ResultDoubleList doHandleRegisterData(ResultDoubleList modbusResults);
 
     SettingsModel* _pSettingsModel;
     GraphDataModel* _pGraphDataModel;

--- a/tests/importexport/tst_projectfilexmlparser.cpp
+++ b/tests/importexport/tst_projectfilexmlparser.cpp
@@ -311,5 +311,3 @@ void TestProjectFileXmlParser::logFileRelativePath()
 }
 
 QTEST_MAIN(TestProjectFileXmlParser)
-
-#include "tst_projectfilexmlparser.moc"


### PR DESCRIPTION
All six model objects in MainApp are now allocated with `this` as Qt parent.
Qt will automatically destroy them in reverse-construction order after MainWindow
is explicitly deleted, eliminating the manual delete sequence and the risk of
future use-after-free from widget destructor accessing already-deleted models.

Fixes issue 1.1 from Plan/architecture_review.md.

https://claude.ai/code/session_01SkgweHpC8xZ1sxbxctvX5R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked several architecture-review checklist items as done.

* **Refactor**
  * Replaced signal-driven data flow with direct synchronous calls and clarified read-only vs mutable data accessors.
  * Adjusted object ownership/parenting for clearer lifetimes.

* **Bug Fixes**
  * Improved memory management and object lifetime handling.

* **Tests**
  * Updated tests to validate returned results with the new synchronous behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->