### PR TITLE
Fix flaky adapter tests: replace qWait with QSignalSpy::wait and add fast-fail guard

### DIFF
--- a/src/ProtocolAdapter/adapterclient.cpp
+++ b/src/ProtocolAdapter/adapterclient.cpp
@@ -4,20 +4,21 @@
 
 #include <QJsonArray>
 
-AdapterClient::AdapterClient(AdapterProcess* pProcess, QObject* parent, int handshakeTimeoutMs)
-    : QObject(parent), _pProcess(pProcess), _handshakeTimeoutMs(handshakeTimeoutMs)
+#include <memory>
+
+AdapterClient::AdapterClient(std::unique_ptr<AdapterProcess> pProcess, QObject* parent, int handshakeTimeoutMs)
+    : QObject(parent), _pProcess(std::move(pProcess)), _handshakeTimeoutMs(handshakeTimeoutMs)
 {
-    Q_ASSERT(pProcess);
-    _pProcess->setParent(this);
+    Q_ASSERT(_pProcess);
 
     _handshakeTimer.setSingleShot(true);
     connect(&_handshakeTimer, &QTimer::timeout, this, &AdapterClient::onHandshakeTimeout);
 
-    connect(_pProcess, &AdapterProcess::responseReceived, this, &AdapterClient::onResponseReceived);
-    connect(_pProcess, &AdapterProcess::errorReceived, this, &AdapterClient::onErrorReceived);
-    connect(_pProcess, &AdapterProcess::processError, this, &AdapterClient::onProcessError);
-    connect(_pProcess, &AdapterProcess::processFinished, this, &AdapterClient::onProcessFinished);
-    connect(_pProcess, &AdapterProcess::notificationReceived, this, &AdapterClient::onNotificationReceived);
+    connect(_pProcess.get(), &AdapterProcess::responseReceived, this, &AdapterClient::onResponseReceived);
+    connect(_pProcess.get(), &AdapterProcess::errorReceived, this, &AdapterClient::onErrorReceived);
+    connect(_pProcess.get(), &AdapterProcess::processError, this, &AdapterClient::onProcessError);
+    connect(_pProcess.get(), &AdapterProcess::processFinished, this, &AdapterClient::onProcessFinished);
+    connect(_pProcess.get(), &AdapterProcess::notificationReceived, this, &AdapterClient::onNotificationReceived);
 }
 
 AdapterClient::~AdapterClient() = default;

--- a/src/ProtocolAdapter/adapterclient.h
+++ b/src/ProtocolAdapter/adapterclient.h
@@ -11,6 +11,8 @@
 #include <QStringList>
 #include <QTimer>
 
+#include <memory>
+
 /*!
  * \brief Lifecycle manager for an external adapter process communicating via JSON-RPC 2.0.
  *
@@ -21,14 +23,16 @@
  *   requestStatus() → getStatus → statusResult()
  *   stopSession() → shutdown → process exit → sessionStopped()
  *
- * Takes ownership of the AdapterProcess passed to the constructor.
+ * Takes ownership of the AdapterProcess passed to the constructor via std::unique_ptr.
  */
 class AdapterClient : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit AdapterClient(AdapterProcess* pProcess, QObject* parent = nullptr, int handshakeTimeoutMs = 10000);
+    explicit AdapterClient(std::unique_ptr<AdapterProcess> pProcess,
+                           QObject* parent = nullptr,
+                           int handshakeTimeoutMs = 10000);
     ~AdapterClient();
 
     /*!
@@ -234,7 +238,7 @@ private:
 
     static constexpr int cHandshakeTimeoutMs = 10000;
 
-    AdapterProcess* _pProcess;
+    std::unique_ptr<AdapterProcess> _pProcess;
     QTimer _handshakeTimer;
     int _handshakeTimeoutMs;
     QJsonObject _pendingConfig;

--- a/src/ProtocolAdapter/adaptermanager.cpp
+++ b/src/ProtocolAdapter/adaptermanager.cpp
@@ -10,11 +10,12 @@
 #include <QDir>
 #include <QFileInfo>
 
+#include <memory>
+
 AdapterManager::AdapterManager(SettingsModel* pSettingsModel, QObject* parent)
     : QObject(parent), _pSettingsModel(pSettingsModel)
 {
-    _pAdapterProcess = new AdapterProcess(this);
-    _pAdapterClient = new AdapterClient(_pAdapterProcess, this);
+    _pAdapterClient = new AdapterClient(std::make_unique<AdapterProcess>(), this);
 
     connect(_pAdapterClient, &AdapterClient::sessionStarted, this, &AdapterManager::sessionStarted);
     connect(_pAdapterClient, &AdapterClient::readDataResult, this, &AdapterManager::readDataResult);

--- a/src/ProtocolAdapter/adaptermanager.h
+++ b/src/ProtocolAdapter/adaptermanager.h
@@ -9,7 +9,6 @@
 #include <QStringList>
 
 class AdapterClient;
-class AdapterProcess;
 class SettingsModel;
 
 /*!
@@ -115,7 +114,6 @@ private slots:
 
 private:
     SettingsModel* _pSettingsModel;
-    AdapterProcess* _pAdapterProcess;
     AdapterClient* _pAdapterClient;
 };
 

--- a/tests/ProtocolAdapter/CMakeLists.txt
+++ b/tests/ProtocolAdapter/CMakeLists.txt
@@ -7,6 +7,8 @@ target_compile_definitions(tst_adapterprocess PRIVATE
     DUMMY_ADAPTER_EXECUTABLE="$<TARGET_FILE:dummymodbusadapter>"
 )
 
+add_dependencies(tst_adapterprocess dummymodbusadapter)
+
 if(UNIX AND NOT APPLE)
     # Derive Qt library path so tests can find Qt shared libraries when run
     # directly from the build tree before a full install (RPATH is $ORIGIN).

--- a/tests/ProtocolAdapter/tst_adapterclient.cpp
+++ b/tests/ProtocolAdapter/tst_adapterclient.cpp
@@ -9,6 +9,8 @@
 #include <QSignalSpy>
 #include <QTest>
 
+#include <memory>
+
 /* ---- Mock AdapterProcess ---- */
 
 /*!
@@ -109,8 +111,9 @@ void TestAdapterClient::cleanup()
 
 void TestAdapterClient::lifecycleInitializeToStart()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyStarted(&client, &AdapterClient::sessionStarted);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
@@ -154,8 +157,9 @@ void TestAdapterClient::lifecycleInitializeToStart()
 
 void TestAdapterClient::describeSignalEmitted()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDescribe(&client, &AdapterClient::describeResult);
 
@@ -174,8 +178,9 @@ void TestAdapterClient::describeSignalEmitted()
 
 void TestAdapterClient::readDataValidResults()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spy(&client, &AdapterClient::readDataResult);
 
@@ -204,8 +209,9 @@ void TestAdapterClient::readDataValidResults()
 
 void TestAdapterClient::readDataEmptyRegisters()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spy(&client, &AdapterClient::readDataResult);
 
@@ -226,8 +232,9 @@ void TestAdapterClient::readDataEmptyRegisters()
 
 void TestAdapterClient::requestStatusEmitsSignal()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spy(&client, &AdapterClient::statusResult);
 
@@ -247,8 +254,9 @@ void TestAdapterClient::requestStatusEmitsSignal()
 
 void TestAdapterClient::errorResponseEmitsSessionError()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spy(&client, &AdapterClient::sessionError);
 
@@ -265,8 +273,9 @@ void TestAdapterClient::errorResponseEmitsSessionError()
 
 void TestAdapterClient::unexpectedResponseEmitsNoSignals()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyStarted(&client, &AdapterClient::sessionStarted);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
@@ -282,8 +291,9 @@ void TestAdapterClient::unexpectedResponseEmitsNoSignals()
 
 void TestAdapterClient::notificationIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyStarted(&client, &AdapterClient::sessionStarted);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
@@ -301,8 +311,9 @@ void TestAdapterClient::notificationIgnored()
 
 void TestAdapterClient::diagnosticNotificationForwarded()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDiagnostic(&client, &AdapterClient::diagnosticReceived);
 
@@ -316,8 +327,9 @@ void TestAdapterClient::diagnosticNotificationForwarded()
 
 void TestAdapterClient::diagnosticNotificationDebugLevel()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDiagnostic(&client, &AdapterClient::diagnosticReceived);
 
@@ -331,8 +343,9 @@ void TestAdapterClient::diagnosticNotificationDebugLevel()
 
 void TestAdapterClient::diagnosticMalformedParams()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDiagnostic(&client, &AdapterClient::diagnosticReceived);
 
@@ -344,8 +357,9 @@ void TestAdapterClient::diagnosticMalformedParams()
 
 void TestAdapterClient::processErrorEmitsSessionError()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spy(&client, &AdapterClient::sessionError);
 
@@ -358,8 +372,9 @@ void TestAdapterClient::processErrorEmitsSessionError()
 
 void TestAdapterClient::stopSessionDuringLifecycle()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
 
@@ -378,8 +393,9 @@ void TestAdapterClient::stopSessionDuringLifecycle()
 
 void TestAdapterClient::doubleStopSession()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
 
@@ -403,8 +419,9 @@ void TestAdapterClient::doubleStopSession()
 
 void TestAdapterClient::requestReadDataWhenNotActive()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyData(&client, &AdapterClient::readDataResult);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
@@ -419,8 +436,9 @@ void TestAdapterClient::requestReadDataWhenNotActive()
 
 void TestAdapterClient::nonObjectResultEmitsSessionError()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
 
@@ -435,8 +453,9 @@ void TestAdapterClient::nonObjectResultEmitsSessionError()
 
 void TestAdapterClient::errorDuringShutdownSuppressed()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
 
@@ -463,8 +482,9 @@ void TestAdapterClient::errorDuringShutdownSuppressed()
 
 void TestAdapterClient::awaitingConfigPausesBeforeConfigure()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDescribe(&client, &AdapterClient::describeResult);
 
@@ -486,8 +506,9 @@ void TestAdapterClient::awaitingConfigPausesBeforeConfigure()
 
 void TestAdapterClient::stopSessionDuringAwaitingConfig()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
 
@@ -507,8 +528,9 @@ void TestAdapterClient::stopSessionDuringAwaitingConfig()
 
 void TestAdapterClient::shutdownNoAckTimesOutToSessionStopped()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock, nullptr, 250 /* ms */);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned), nullptr, 250 /* ms */);
 
     QSignalSpy spyStopped(&client, &AdapterClient::sessionStopped);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
@@ -535,8 +557,9 @@ void TestAdapterClient::shutdownNoAckTimesOutToSessionStopped()
 
 void TestAdapterClient::shutdownAckEmitsSessionStoppedAfterProcessExit()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyStopped(&client, &AdapterClient::sessionStopped);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
@@ -567,8 +590,9 @@ void TestAdapterClient::shutdownAckEmitsSessionStoppedAfterProcessExit()
 
 void TestAdapterClient::processErrorDuringStoppingNoSessionError()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
     QSignalSpy spyStopped(&client, &AdapterClient::sessionStopped);
@@ -589,8 +613,9 @@ void TestAdapterClient::processErrorDuringStoppingNoSessionError()
 
 void TestAdapterClient::processErrorDuringStoppingThenProcessFinished()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
     QSignalSpy spyStopped(&client, &AdapterClient::sessionStopped);
@@ -629,8 +654,9 @@ static void driveToActive(AdapterClient& client, MockAdapterProcess* mock)
 
 void TestAdapterClient::requestDataPointSchemaEmitsSignal()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spySchema(&client, &AdapterClient::dataPointSchemaResult);
 
@@ -651,8 +677,9 @@ void TestAdapterClient::requestDataPointSchemaEmitsSignal()
 
 void TestAdapterClient::requestDataPointSchemaInWrongStateIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spySchema(&client, &AdapterClient::dataPointSchemaResult);
 
@@ -665,8 +692,9 @@ void TestAdapterClient::requestDataPointSchemaInWrongStateIgnored()
 
 void TestAdapterClient::describeDataPointInAwaitingConfig()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDescReg(&client, &AdapterClient::describeDataPointResult);
 
@@ -690,8 +718,9 @@ void TestAdapterClient::describeDataPointInAwaitingConfig()
 
 void TestAdapterClient::describeDataPointInActiveState()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDescReg(&client, &AdapterClient::describeDataPointResult);
 
@@ -709,8 +738,9 @@ void TestAdapterClient::describeDataPointInActiveState()
 
 void TestAdapterClient::describeDataPointInWrongStateIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyDescReg(&client, &AdapterClient::describeDataPointResult);
 
@@ -723,8 +753,9 @@ void TestAdapterClient::describeDataPointInWrongStateIgnored()
 
 void TestAdapterClient::validateDataPointValid()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyValidate(&client, &AdapterClient::validateDataPointResult);
 
@@ -744,8 +775,9 @@ void TestAdapterClient::validateDataPointValid()
 
 void TestAdapterClient::validateDataPointInvalid()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyValidate(&client, &AdapterClient::validateDataPointResult);
 
@@ -763,8 +795,9 @@ void TestAdapterClient::validateDataPointInvalid()
 
 void TestAdapterClient::validateDataPointInActiveState()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyValidate(&client, &AdapterClient::validateDataPointResult);
 
@@ -784,8 +817,9 @@ void TestAdapterClient::validateDataPointInActiveState()
 
 void TestAdapterClient::validateDataPointInWrongStateIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyValidate(&client, &AdapterClient::validateDataPointResult);
 
@@ -798,8 +832,9 @@ void TestAdapterClient::validateDataPointInWrongStateIgnored()
 
 void TestAdapterClient::buildExpressionRequestAndResponse()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyBuild(&client, &AdapterClient::buildExpressionResult);
 
@@ -824,8 +859,9 @@ void TestAdapterClient::buildExpressionRequestAndResponse()
 
 void TestAdapterClient::buildExpressionInActiveState()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyBuild(&client, &AdapterClient::buildExpressionResult);
 
@@ -847,8 +883,9 @@ void TestAdapterClient::buildExpressionInActiveState()
 
 void TestAdapterClient::buildExpressionInWrongStateIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyBuild(&client, &AdapterClient::buildExpressionResult);
 
@@ -861,8 +898,9 @@ void TestAdapterClient::buildExpressionInWrongStateIgnored()
 
 void TestAdapterClient::buildExpressionOmitsDefaultDataType()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     driveToAwaitingConfig(client, mock);
 
@@ -874,8 +912,9 @@ void TestAdapterClient::buildExpressionOmitsDefaultDataType()
 
 void TestAdapterClient::buildExpressionOmitsDefaultDeviceId()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     driveToAwaitingConfig(client, mock);
 
@@ -887,8 +926,9 @@ void TestAdapterClient::buildExpressionOmitsDefaultDeviceId()
 
 void TestAdapterClient::expressionHelpRequestAndResponse()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyHelp(&client, &AdapterClient::expressionHelpResult);
 
@@ -908,8 +948,9 @@ void TestAdapterClient::expressionHelpRequestAndResponse()
 
 void TestAdapterClient::expressionHelpInActiveState()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyHelp(&client, &AdapterClient::expressionHelpResult);
 
@@ -927,8 +968,9 @@ void TestAdapterClient::expressionHelpInActiveState()
 
 void TestAdapterClient::expressionHelpInWrongStateIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyHelp(&client, &AdapterClient::expressionHelpResult);
 
@@ -941,8 +983,9 @@ void TestAdapterClient::expressionHelpInWrongStateIgnored()
 
 void TestAdapterClient::expressionHelpErrorIsNonFatal()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
     QSignalSpy spyHelp(&client, &AdapterClient::expressionHelpResult);
@@ -969,8 +1012,9 @@ void TestAdapterClient::expressionHelpErrorIsNonFatal()
 
 void TestAdapterClient::readDataErrorIsNonFatal()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
     QSignalSpy spyData(&client, &AdapterClient::readDataResult);
@@ -1006,8 +1050,9 @@ void TestAdapterClient::readDataErrorIsNonFatal()
 
 void TestAdapterClient::readDataErrorInNonActiveStateIsIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
     QSignalSpy spyData(&client, &AdapterClient::readDataResult);
@@ -1026,8 +1071,9 @@ void TestAdapterClient::readDataErrorInNonActiveStateIsIgnored()
 
 void TestAdapterClient::readDataErrorInIdleStateIsIgnored()
 {
-    auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock);
+    auto mockOwned = std::make_unique<MockAdapterProcess>();
+    auto* mock = mockOwned.get();
+    AdapterClient client(std::move(mockOwned));
 
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
     QSignalSpy spyData(&client, &AdapterClient::readDataResult);

--- a/tests/ProtocolAdapter/tst_adapterclient.cpp
+++ b/tests/ProtocolAdapter/tst_adapterclient.cpp
@@ -508,7 +508,7 @@ void TestAdapterClient::stopSessionDuringAwaitingConfig()
 void TestAdapterClient::shutdownNoAckTimesOutToSessionStopped()
 {
     auto* mock = new MockAdapterProcess();
-    AdapterClient client(mock, nullptr, 50 /* ms */);
+    AdapterClient client(mock, nullptr, 250 /* ms */);
 
     QSignalSpy spyStopped(&client, &AdapterClient::sessionStopped);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);
@@ -526,7 +526,7 @@ void TestAdapterClient::shutdownNoAckTimesOutToSessionStopped()
     QCOMPARE(mock->sentRequests.last().method, QStringLiteral("adapter.shutdown"));
 
     /* Wait for the shutdown timer to fire */
-    QTest::qWait(150);
+    QVERIFY2(spyStopped.wait(2000), "sessionStopped not emitted after shutdown timeout");
 
     /* sessionStopped must be emitted, not sessionError */
     QCOMPARE(spyStopped.count(), 1);

--- a/tests/ProtocolAdapter/tst_adapterprocess.cpp
+++ b/tests/ProtocolAdapter/tst_adapterprocess.cpp
@@ -46,8 +46,8 @@ void TestAdapterProcess::sendRequestEmitsResponseReceived()
     /* Close the write channel so the adapter flushes its responses and exits */
     process.stop();
 
-    /* stop() is non-blocking; give the event loop time to receive the response */
-    QTest::qWait(500);
+    /* stop() is non-blocking; wait until the response arrives */
+    QVERIFY2(spyResponse.wait(5000), "responseReceived not emitted");
 
     QCOMPARE(spyProcessError.count(), 0);
     QCOMPARE(spyResponse.count(), 1);
@@ -69,8 +69,8 @@ void TestAdapterProcess::processFinishedEmittedOnStop()
 
     process.stop();
 
-    /* stop() is non-blocking; give the event loop time to process the exit */
-    QTest::qWait(500);
+    /* stop() is non-blocking; wait until the process exits */
+    QVERIFY2(spyFinished.wait(5000), "processFinished not emitted");
 
     QVERIFY(!process.isRunning());
     QCOMPARE(spyFinished.count(), 1);

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -8,6 +8,8 @@ target_compile_definitions(tst_dummyadapter PRIVATE
 
 target_link_libraries(tst_dummyadapter Qt::Test ${QT_LIB} ${SCOPESOURCE})
 
+add_dependencies(tst_dummyadapter dummymodbusadapter)
+
 add_test(NAME tst_dummyadapter COMMAND tst_dummyadapter)
 
 if(UNIX AND NOT APPLE)

--- a/tests/integration/tst_dummyadapter.cpp
+++ b/tests/integration/tst_dummyadapter.cpp
@@ -10,6 +10,8 @@
 #include <QSignalSpy>
 #include <QTest>
 
+#include <memory>
+
 namespace {
 
 constexpr int cSessionTimeoutMs = 10000;
@@ -68,7 +70,7 @@ QJsonObject realConfig()
 void TestDummyAdapter::initTestCase()
 {
     const QString executable = QString::fromUtf8(DUMMY_ADAPTER_EXECUTABLE);
-    QVERIFY2(QFileInfo(executable).exists(),
+    QVERIFY2(QFileInfo::exists(executable),
              qPrintable(QStringLiteral("DUMMY_ADAPTER_EXECUTABLE not found on disk: %1").arg(executable)));
     QVERIFY2(QFileInfo(executable).isExecutable(),
              qPrintable(QStringLiteral("DUMMY_ADAPTER_EXECUTABLE is not executable: %1").arg(executable)));
@@ -83,7 +85,7 @@ void TestDummyAdapter::initTestCase()
  */
 void TestDummyAdapter::init()
 {
-    _pClient = new AdapterClient(new AdapterProcess(), this);
+    _pClient = new AdapterClient(std::make_unique<AdapterProcess>(), this);
 }
 
 /*!

--- a/tests/integration/tst_dummyadapter.cpp
+++ b/tests/integration/tst_dummyadapter.cpp
@@ -4,6 +4,7 @@
 #include "ProtocolAdapter/adapterprocess.h"
 #include "util/result.h"
 
+#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QSignalSpy>
@@ -56,6 +57,22 @@ QJsonObject realConfig()
 }
 
 } // namespace
+
+/*!
+ * \brief Asserts that the dummy adapter binary is executable before any test runs.
+ *
+ * If the binary is missing or not executable every QSignalSpy::wait() would
+ * run to its full ceiling, making the suite hang for minutes before failing.
+ * Catching it here gives an immediate, actionable error message instead.
+ */
+void TestDummyAdapter::initTestCase()
+{
+    const QString executable = QString::fromUtf8(DUMMY_ADAPTER_EXECUTABLE);
+    QVERIFY2(QFileInfo(executable).exists(),
+             qPrintable(QStringLiteral("DUMMY_ADAPTER_EXECUTABLE not found on disk: %1").arg(executable)));
+    QVERIFY2(QFileInfo(executable).isExecutable(),
+             qPrintable(QStringLiteral("DUMMY_ADAPTER_EXECUTABLE is not executable: %1").arg(executable)));
+}
 
 /*!
  * \brief Creates a fresh AdapterClient before each test.

--- a/tests/integration/tst_dummyadapter.h
+++ b/tests/integration/tst_dummyadapter.h
@@ -15,6 +15,7 @@ class TestDummyAdapter : public QObject
 {
     Q_OBJECT
 private slots:
+    void initTestCase();
     void init();
     void cleanup();
     void describeResultHasRequiredFields();


### PR DESCRIPTION
Replace fixed QTest::qWait() delays in tst_adapterclient, tst_adapterprocess,
and tst_dummyadapter with QSignalSpy::wait() so tests end as soon as the signal
fires rather than spinning a fixed wall-clock duration. Bump the shutdown-timeout
timer from 50→250 ms and its ceiling from 150→2000 ms. Add initTestCase() to
tst_dummyadapter that asserts the dummy adapter binary exists and is executable,
aborting the suite immediately rather than hanging for minutes on every wait().
Add add_dependencies on dummymodbusadapter for both integration and ProtocolAdapter
test targets to make the build-graph dependency explicit.

https://claude.ai/code/session_013ovGwQgpk9JiEL83LHiyHC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced memory management for improved stability and safety.

* **Tests**
  * Improved test reliability through deterministic signal waiting instead of fixed delays.
  * Added initialisation checks to verify test prerequisites before execution.
  * Updated build dependencies to ensure correct test execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->