### PR TITLE
Use adapter schema defaults for new-register expression

### DIFF
--- a/src/ProtocolAdapter/adaptermanager.cpp
+++ b/src/ProtocolAdapter/adaptermanager.cpp
@@ -58,6 +58,12 @@ void AdapterManager::startSession(const QStringList& registerExpressions)
     _pAdapterClient->provideConfig(config, registerExpressions);
 }
 
+/*! \brief Returns the identifier string of the active adapter. */
+QString AdapterManager::adapterId() const
+{
+    return QStringLiteral("modbus");
+}
+
 /*! \brief Returns true when the adapter is ready to accept provideConfig() (AWAITING_CONFIG state). */
 bool AdapterManager::isAdapterReady() const
 {

--- a/src/ProtocolAdapter/adaptermanager.h
+++ b/src/ProtocolAdapter/adaptermanager.h
@@ -48,6 +48,11 @@ public:
     virtual void stopSession();
 
     /*!
+     * \brief Returns the identifier string of the active adapter.
+     */
+    virtual QString adapterId() const;
+
+    /*!
      * \brief Returns true when the adapter is in AWAITING_CONFIG and ready for provideConfig().
      */
     virtual bool isAdapterReady() const;

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -106,11 +106,18 @@ void AddRegisterWidget::handleResultAccept()
       static_cast<deviceId_t>(allValues.take(QStringLiteral("deviceId")).toInt(Device::cFirstDeviceId));
 
     _pUi->btnAdd->setEnabled(false);
+    _pendingBuildExpression = true;
     _pAdapterManager->buildExpression(allValues, dataType, deviceId);
 }
 
 void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
 {
+    if (!_pendingBuildExpression)
+    {
+        return;
+    }
+    _pendingBuildExpression = false;
+
     _pUi->btnAdd->setEnabled(true);
 
     if (expression.isEmpty())

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -53,6 +53,7 @@ private:
 
     /* Temporary storage while waiting for buildExpression response */
     GraphData _pendingGraphData;
+    bool _pendingBuildExpression = false;
 };
 
 #endif // ADDREGISTERWIDGET_H

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -74,8 +74,7 @@ RegisterDialog::RegisterDialog(GraphDataModel* pGraphDataModel,
     connect(_pUi->btnRemove, &QPushButton::released, this, &RegisterDialog::removeRegisterRow);
     connect(_pGraphDataModel, &GraphDataModel::rowsInserted, this, &RegisterDialog::onRegisterInserted);
 
-    const QStringList ids = _pSettingsModel->adapterIds();
-    const QString adapterId = ids.isEmpty() ? QString() : ids.first();
+    const QString adapterId = _pAdapterManager->adapterId();
     if (!adapterId.isEmpty())
     {
         auto registerPopupMenu = new AddRegisterWidget(_pSettingsModel, adapterId, _pAdapterManager, this);
@@ -190,13 +189,8 @@ bool RegisterDialog::sortRegistersLastFirst(const QModelIndex& s1, const QModelI
  */
 void RegisterDialog::requestDefaultExpression()
 {
-    const QStringList ids = _pSettingsModel->adapterIds();
-    if (ids.isEmpty())
-    {
-        return;
-    }
-
-    const QJsonObject defaults = _pSettingsModel->adapterData(ids.first())->dataPointSchema()["defaults"].toObject();
+    const QJsonObject defaults =
+      _pSettingsModel->adapterData(_pAdapterManager->adapterId())->dataPointSchema().value("defaults").toObject();
     if (defaults.isEmpty())
     {
         return;
@@ -206,8 +200,8 @@ void RegisterDialog::requestDefaultExpression()
     {
         QObject::disconnect(_defaultExpressionConn);
     }
-    _defaultExpressionConn = connect(_pAdapterManager, &AdapterManager::buildExpressionResult,
-                                     this, &RegisterDialog::onDefaultExpressionBuilt);
+    _defaultExpressionConn = connect(_pAdapterManager, &AdapterManager::buildExpressionResult, this,
+                                     &RegisterDialog::onDefaultExpressionBuilt);
 
     QJsonObject addressFields = defaults;
     const QString dataType = addressFields.take(QStringLiteral("dataType")).toString();

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -205,6 +205,7 @@ void RegisterDialog::requestDefaultExpression()
 
     QJsonObject addressFields = defaults;
     const QString dataType = addressFields.take(QStringLiteral("dataType")).toString();
+    _pendingDefaultExpression = true;
     _pAdapterManager->buildExpression(addressFields, dataType, 0);
 }
 
@@ -214,6 +215,12 @@ void RegisterDialog::requestDefaultExpression()
  */
 void RegisterDialog::onDefaultExpressionBuilt(const QString& expression)
 {
+    if (!_pendingDefaultExpression)
+    {
+        return;
+    }
+
+    _pendingDefaultExpression = false;
     QObject::disconnect(_defaultExpressionConn);
     _defaultExpressionConn = {};
 

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -27,6 +27,8 @@ RegisterDialog::RegisterDialog(GraphDataModel* pGraphDataModel,
     _pSettingsModel = pSettingsModel;
     _pAdapterManager = pAdapterManager;
 
+    connect(_pAdapterManager, &AdapterManager::sessionStarted, this, &RegisterDialog::requestDefaultExpression);
+
     // Setup registerView
     _pUi->registerView->setModel(_pGraphDataModel);
     _pUi->registerView->verticalHeader()->hide();
@@ -178,4 +180,51 @@ int RegisterDialog::selectedRowAfterDelete(int deletedStartIndex, int rowCnt)
 bool RegisterDialog::sortRegistersLastFirst(const QModelIndex& s1, const QModelIndex& s2)
 {
     return s1.row() > s2.row();
+}
+
+/*!
+ * \brief Requests a default expression from the adapter using its own schema defaults.
+ *
+ * Called when the adapter session starts. The result is used to keep the default new-register
+ * expression in sync with whatever the adapter considers its default data point.
+ */
+void RegisterDialog::requestDefaultExpression()
+{
+    const QStringList ids = _pSettingsModel->adapterIds();
+    if (ids.isEmpty())
+    {
+        return;
+    }
+
+    const QJsonObject defaults = _pSettingsModel->adapterData(ids.first())->dataPointSchema()["defaults"].toObject();
+    if (defaults.isEmpty())
+    {
+        return;
+    }
+
+    if (_defaultExpressionConn)
+    {
+        QObject::disconnect(_defaultExpressionConn);
+    }
+    _defaultExpressionConn = connect(_pAdapterManager, &AdapterManager::buildExpressionResult,
+                                     this, &RegisterDialog::onDefaultExpressionBuilt);
+
+    QJsonObject addressFields = defaults;
+    const QString dataType = addressFields.take(QStringLiteral("dataType")).toString();
+    _pAdapterManager->buildExpression(addressFields, dataType, 0);
+}
+
+/*!
+ * \brief Applies the adapter-provided default expression to the graph data model.
+ * \param expression The default expression string returned by the adapter.
+ */
+void RegisterDialog::onDefaultExpressionBuilt(const QString& expression)
+{
+    QObject::disconnect(_defaultExpressionConn);
+    _defaultExpressionConn = {};
+
+    if (!expression.isEmpty())
+    {
+        _pGraphDataModel->setDefaultExpression(expression);
+    }
 }

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -4,6 +4,7 @@
 #include "customwidgets/centeredbox.h"
 
 #include <QDialog>
+#include <QMetaObject>
 #include <QWidgetAction>
 
 /* Forward declaration */
@@ -36,6 +37,8 @@ private slots:
     void activatedCell(QModelIndex modelIndex);
     void onRegisterInserted(const QModelIndex& parent, int first, int last);
     void handleExpressionEdit(const QModelIndex& index);
+    void requestDefaultExpression();
+    void onDefaultExpressionBuilt(const QString& expression);
 
 private:
     int selectedRowAfterDelete(int deletedStartIndex, int rowCnt);
@@ -52,6 +55,8 @@ private:
     std::unique_ptr<RegisterValueAxisDelegate> _valueAxisDelegate;
     std::unique_ptr<ActionButtonDelegate> _expressionDelegate;
     std::unique_ptr<QWidgetAction> _registerPopupAction;
+
+    QMetaObject::Connection _defaultExpressionConn;
 };
 
 #endif // REGISTERDIALOG_H

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -57,6 +57,7 @@ private:
     std::unique_ptr<QWidgetAction> _registerPopupAction;
 
     QMetaObject::Connection _defaultExpressionConn;
+    bool _pendingDefaultExpression = false;
 };
 
 #endif // REGISTERDIALOG_H

--- a/src/models/graphdatamodel.cpp
+++ b/src/models/graphdatamodel.cpp
@@ -14,6 +14,7 @@ GraphDataModel::GraphDataModel(QObject* parent) : QAbstractTableModel(parent), _
     _endTime = 0;
     _successCount = 0;
     _errorCount = 0;
+    _defaultExpression = QStringLiteral("${h0}");
 
     connect(this, &GraphDataModel::visibilityChanged, this, &GraphDataModel::modelDataChanged);
     connect(this, &GraphDataModel::labelChanged, this, &GraphDataModel::modelDataChanged);
@@ -564,12 +565,22 @@ void GraphDataModel::add(QList<GraphData> graphDataList)
 void GraphDataModel::add()
 {
     GraphData data;
-
-    quint32 registerAddr = 40001;
     data.setLabel("New curve");
-    data.setExpression(QString("${%1}").arg(registerAddr));
-
+    data.setExpression(_defaultExpression);
     add(data);
+}
+
+/*!
+ * \brief Sets the default expression used when adding a new register without an explicit expression.
+ * \param expression The expression string to use as the default (e.g. \c ${h0}).
+ */
+void GraphDataModel::setDefaultExpression(const QString& expression)
+{
+    if (expression.isEmpty())
+    {
+        return;
+    }
+    _defaultExpression = expression;
 }
 
 void GraphDataModel::add(QList<QString> labelList)

--- a/src/models/graphdatamodel.h
+++ b/src/models/graphdatamodel.h
@@ -78,6 +78,7 @@ public:
     void setCommunicationEndTime(qint64 endTime);
     void setCommunicationStats(quint32 successCount, quint32 errorCount);
     void setMedianPollTime(quint32 pollTime);
+    void setDefaultExpression(const QString& expression);
 
     void add(GraphData rowData);
     void add(QList<GraphData> graphDataList);
@@ -128,6 +129,8 @@ private:
     quint32 _successCount;
     quint32 _errorCount;
     quint32 _medianPollTime;
+
+    QString _defaultExpression;
 
     QList<GraphData> _graphData;
     QList<quint32> _activeGraphList;

--- a/tests/models/CMakeLists.txt
+++ b/tests/models/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_xtest(tst_diagnostic)
 add_xtest(tst_diagnosticmodel)
 add_xtest(tst_graphdata)
+add_xtest(tst_graphdatamodel)
 add_xtest(tst_adapterdata)

--- a/tests/models/tst_graphdatamodel.cpp
+++ b/tests/models/tst_graphdatamodel.cpp
@@ -1,0 +1,56 @@
+
+#include "tst_graphdatamodel.h"
+
+#include "models/graphdatamodel.h"
+
+#include <QTest>
+
+void TestGraphDataModel::init()
+{
+}
+
+void TestGraphDataModel::cleanup()
+{
+}
+
+void TestGraphDataModel::addUsesDefaultExpression()
+{
+    GraphDataModel model;
+    model.add();
+
+    QCOMPARE(model.expression(0), QStringLiteral("${h0}"));
+}
+
+void TestGraphDataModel::addUsesCustomDefaultExpression()
+{
+    GraphDataModel model;
+    model.setDefaultExpression(QStringLiteral("${h5:s16b}"));
+    model.add();
+
+    QCOMPARE(model.expression(0), QStringLiteral("${h5:s16b}"));
+}
+
+void TestGraphDataModel::setDefaultExpressionUpdatesSubsequentAdds()
+{
+    GraphDataModel model;
+
+    model.add();
+    QCOMPARE(model.expression(0), QStringLiteral("${h0}"));
+
+    model.setDefaultExpression(QStringLiteral("${i10}"));
+    model.add();
+    QCOMPARE(model.expression(0), QStringLiteral("${h0}"));
+    QCOMPARE(model.expression(1), QStringLiteral("${i10}"));
+}
+
+void TestGraphDataModel::setDefaultExpressionIgnoresEmptyString()
+{
+    GraphDataModel model;
+    model.setDefaultExpression(QStringLiteral("${i0}"));
+    model.setDefaultExpression(QString());
+    model.add();
+
+    QCOMPARE(model.expression(0), QStringLiteral("${i0}"));
+}
+
+QTEST_GUILESS_MAIN(TestGraphDataModel)

--- a/tests/models/tst_graphdatamodel.h
+++ b/tests/models/tst_graphdatamodel.h
@@ -1,0 +1,20 @@
+
+#ifndef TST_GRAPHDATAMODEL_H
+#define TST_GRAPHDATAMODEL_H
+
+#include <QObject>
+
+class TestGraphDataModel : public QObject
+{
+    Q_OBJECT
+private slots:
+    void init();
+    void cleanup();
+
+    void addUsesDefaultExpression();
+    void addUsesCustomDefaultExpression();
+    void setDefaultExpressionUpdatesSubsequentAdds();
+    void setDefaultExpressionIgnoresEmptyString();
+};
+
+#endif /* TST_GRAPHDATAMODEL_H */


### PR DESCRIPTION
GraphDataModel::add() hardcoded \${40001}. Now it uses a configurable
_defaultExpression (default: \${h0}). RegisterDialog connects to
AdapterManager::sessionStarted and calls buildExpression with the
adapter's dataPointSchema defaults; the result is stored via
setDefaultExpression so every subsequent direct Add click produces
the adapter-defined default expression.

Added _pendingBuildExpression guard in AddRegisterWidget so that the
buildExpressionResult broadcast from RegisterDialog's probe does not
trigger a spurious graphDataConfigured emission.

https://claude.ai/code/session_01YSsLBJRhZ5a7SMbj4f1Crr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-initialise default expression for new graphs/registers from the active session; allow configuring the default expression.
* **Bug Fixes**
  * Prevent late/unsolicited expression results from affecting the UI; Add button is disabled while an expression build is pending.
* **Tests**
  * Added tests covering default-expression behaviour, updates and edge cases for the graph data model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->