### PR TITLE
Replace dual bool flags with PollState enum in AdapterPoll

### DIFF
--- a/src/communication/adapterpoll.cpp
+++ b/src/communication/adapterpoll.cpp
@@ -19,14 +19,7 @@ AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, QObject* parent)
 
     connect(_pAdapterManager, &AdapterManager::sessionStarted, this, &AdapterPoll::triggerRegisterRead);
     connect(_pAdapterManager, &AdapterManager::readDataResult, this, &AdapterPoll::onReadDataResult);
-    connect(_pAdapterManager, &AdapterManager::sessionError, this, [this](QString message) {
-        qCWarning(scopeComm) << "AdapterManager error:" << message;
-        if (_pollState == PollState::WaitingForAdapter)
-        {
-            disconnect(_adapterReadyConnection);
-        }
-        _pollState = PollState::Inactive;
-    });
+    connect(_pAdapterManager, &AdapterManager::sessionError, this, &AdapterPoll::onSessionError);
 }
 
 AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, AdapterManager* pAdapterManager, QObject* parent)
@@ -43,14 +36,7 @@ AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, AdapterManager* pAdapter
 
     connect(_pAdapterManager, &AdapterManager::sessionStarted, this, &AdapterPoll::triggerRegisterRead);
     connect(_pAdapterManager, &AdapterManager::readDataResult, this, &AdapterPoll::onReadDataResult);
-    connect(_pAdapterManager, &AdapterManager::sessionError, this, [this](QString message) {
-        qCWarning(scopeComm) << "AdapterManager error:" << message;
-        if (_pollState == PollState::WaitingForAdapter)
-        {
-            disconnect(_adapterReadyConnection);
-        }
-        _pollState = PollState::Inactive;
-    });
+    connect(_pAdapterManager, &AdapterManager::sessionError, this, &AdapterPoll::onSessionError);
 }
 
 AdapterPoll::~AdapterPoll() = default;
@@ -109,6 +95,7 @@ void AdapterPoll::stopCommunication()
     if (_pollState == PollState::WaitingForAdapter)
     {
         disconnect(_adapterReadyConnection);
+        _adapterReadyConnection = {};
     }
     _pollState = PollState::Inactive;
     _pendingExpressions.clear();
@@ -170,6 +157,17 @@ void AdapterPoll::onAdapterReady()
         _pAdapterManager->startSession(_pendingExpressions);
         _pendingExpressions.clear();
     }
+}
+
+void AdapterPoll::onSessionError(const QString& message)
+{
+    qCWarning(scopeComm) << "AdapterManager error:" << message;
+    if (_pollState == PollState::WaitingForAdapter)
+    {
+        disconnect(_adapterReadyConnection);
+        _adapterReadyConnection = {};
+    }
+    _pollState = PollState::Inactive;
 }
 
 QStringList AdapterPoll::buildRegisterExpressions(const QList<DataPoint>& registerList)

--- a/src/communication/adapterpoll.cpp
+++ b/src/communication/adapterpoll.cpp
@@ -5,8 +5,7 @@
 #include "util/formatdatetime.h"
 #include "util/scopelogging.h"
 
-AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, QObject* parent)
-    : QObject(parent)
+AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, QObject* parent) : QObject(parent)
 {
     _pPollTimer = new QTimer(this);
     _pPollTimer->setSingleShot(true);

--- a/src/communication/adapterpoll.cpp
+++ b/src/communication/adapterpoll.cpp
@@ -21,6 +21,10 @@ AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, QObject* parent)
     connect(_pAdapterManager, &AdapterManager::readDataResult, this, &AdapterPoll::onReadDataResult);
     connect(_pAdapterManager, &AdapterManager::sessionError, this, [this](QString message) {
         qCWarning(scopeComm) << "AdapterManager error:" << message;
+        if (_pollState == PollState::WaitingForAdapter)
+        {
+            disconnect(_adapterReadyConnection);
+        }
         _pollState = PollState::Inactive;
     });
 }
@@ -41,6 +45,10 @@ AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, AdapterManager* pAdapter
     connect(_pAdapterManager, &AdapterManager::readDataResult, this, &AdapterPoll::onReadDataResult);
     connect(_pAdapterManager, &AdapterManager::sessionError, this, [this](QString message) {
         qCWarning(scopeComm) << "AdapterManager error:" << message;
+        if (_pollState == PollState::WaitingForAdapter)
+        {
+            disconnect(_adapterReadyConnection);
+        }
         _pollState = PollState::Inactive;
     });
 }

--- a/src/communication/adapterpoll.cpp
+++ b/src/communication/adapterpoll.cpp
@@ -126,24 +126,26 @@ void AdapterPoll::triggerRegisterRead()
 
 void AdapterPoll::onReadDataResult(ResultDoubleList results)
 {
+    if (_pollState != PollState::Active)
+    {
+        return;
+    }
+
     emit registerDataReady(results);
 
-    if (_pollState == PollState::Active)
+    const quint32 passedInterval = static_cast<quint32>(QDateTime::currentMSecsSinceEpoch() - _lastPollStart);
+    uint waitInterval;
+
+    if (passedInterval > _pSettingsModel->pollTime())
     {
-        const quint32 passedInterval = static_cast<quint32>(QDateTime::currentMSecsSinceEpoch() - _lastPollStart);
-        uint waitInterval;
-
-        if (passedInterval > _pSettingsModel->pollTime())
-        {
-            waitInterval = 1;
-        }
-        else
-        {
-            waitInterval = _pSettingsModel->pollTime() - passedInterval;
-        }
-
-        _pPollTimer->start(static_cast<int>(waitInterval));
+        waitInterval = 1;
     }
+    else
+    {
+        waitInterval = _pSettingsModel->pollTime() - passedInterval;
+    }
+
+    _pPollTimer->start(static_cast<int>(waitInterval));
 }
 
 /*! \brief Returns the AdapterManager owned by this instance. */

--- a/src/communication/adapterpoll.cpp
+++ b/src/communication/adapterpoll.cpp
@@ -6,7 +6,7 @@
 #include "util/scopelogging.h"
 
 AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, QObject* parent)
-    : QObject(parent), _bPollActive(false), _bWaitingForAdapterReady(false)
+    : QObject(parent)
 {
     _pPollTimer = new QTimer(this);
     _pPollTimer->setSingleShot(true);
@@ -21,12 +21,12 @@ AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, QObject* parent)
     connect(_pAdapterManager, &AdapterManager::readDataResult, this, &AdapterPoll::onReadDataResult);
     connect(_pAdapterManager, &AdapterManager::sessionError, this, [this](QString message) {
         qCWarning(scopeComm) << "AdapterManager error:" << message;
-        _bPollActive = false;
+        _pollState = PollState::Inactive;
     });
 }
 
 AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, AdapterManager* pAdapterManager, QObject* parent)
-    : QObject(parent), _bPollActive(false), _bWaitingForAdapterReady(false)
+    : QObject(parent)
 {
     _pPollTimer = new QTimer(this);
     _pPollTimer->setSingleShot(true);
@@ -41,7 +41,7 @@ AdapterPoll::AdapterPoll(SettingsModel* pSettingsModel, AdapterManager* pAdapter
     connect(_pAdapterManager, &AdapterManager::readDataResult, this, &AdapterPoll::onReadDataResult);
     connect(_pAdapterManager, &AdapterManager::sessionError, this, [this](QString message) {
         qCWarning(scopeComm) << "AdapterManager error:" << message;
-        _bPollActive = false;
+        _pollState = PollState::Inactive;
     });
 }
 
@@ -61,7 +61,6 @@ void AdapterPoll::initAdapter()
 void AdapterPoll::startCommunication(QList<DataPoint>& registerList)
 {
     _registerList = registerList;
-    _bPollActive = true;
 
     qCInfo(scopeComm) << "Active registers: " << DataPoint::dumpListToString(_registerList);
     qCInfo(scopeComm) << qUtf8Printable(QString("Start logging: %1").arg(FormatDateTime::currentDateTime()));
@@ -72,14 +71,15 @@ void AdapterPoll::startCommunication(QList<DataPoint>& registerList)
 
     if (_pAdapterManager->isAdapterReady())
     {
+        _pollState = PollState::Active;
         _pAdapterManager->startSession(expressions);
     }
     else
     {
         _pendingExpressions = expressions;
-        if (!_bWaitingForAdapterReady)
+        if (_pollState != PollState::WaitingForAdapter)
         {
-            _bWaitingForAdapterReady = true;
+            _pollState = PollState::WaitingForAdapter;
             _adapterReadyConnection = connect(_pAdapterManager, &AdapterManager::adapterReady, this,
                                               &AdapterPoll::onAdapterReady, Qt::SingleShotConnection);
         }
@@ -98,12 +98,11 @@ void AdapterPoll::resetCommunicationStats()
 
 void AdapterPoll::stopCommunication()
 {
-    _bPollActive = false;
-    if (_bWaitingForAdapterReady)
+    if (_pollState == PollState::WaitingForAdapter)
     {
         disconnect(_adapterReadyConnection);
-        _bWaitingForAdapterReady = false;
     }
+    _pollState = PollState::Inactive;
     _pendingExpressions.clear();
     _pPollTimer->stop();
     _pAdapterManager->stopSession();
@@ -113,12 +112,12 @@ void AdapterPoll::stopCommunication()
 
 bool AdapterPoll::isActive() const
 {
-    return _bPollActive;
+    return _pollState != PollState::Inactive;
 }
 
 void AdapterPoll::triggerRegisterRead()
 {
-    if (_bPollActive)
+    if (_pollState == PollState::Active)
     {
         _lastPollStart = QDateTime::currentMSecsSinceEpoch();
         _pAdapterManager->requestReadData();
@@ -129,7 +128,7 @@ void AdapterPoll::onReadDataResult(ResultDoubleList results)
 {
     emit registerDataReady(results);
 
-    if (_bPollActive)
+    if (_pollState == PollState::Active)
     {
         const quint32 passedInterval = static_cast<quint32>(QDateTime::currentMSecsSinceEpoch() - _lastPollStart);
         uint waitInterval;
@@ -155,9 +154,9 @@ AdapterManager* AdapterPoll::adapterManager() const
 
 void AdapterPoll::onAdapterReady()
 {
-    _bWaitingForAdapterReady = false;
-    if (_bPollActive)
+    if (_pollState == PollState::WaitingForAdapter)
     {
+        _pollState = PollState::Active;
         _pAdapterManager->startSession(_pendingExpressions);
         _pendingExpressions.clear();
     }

--- a/src/communication/adapterpoll.h
+++ b/src/communication/adapterpoll.h
@@ -48,6 +48,7 @@ private slots:
     void triggerRegisterRead();
     void onReadDataResult(ResultDoubleList results);
     void onAdapterReady();
+    void onSessionError(const QString& message);
 
 private:
     QStringList buildRegisterExpressions(const QList<DataPoint>& registerList);

--- a/src/communication/adapterpoll.h
+++ b/src/communication/adapterpoll.h
@@ -52,11 +52,17 @@ private slots:
 private:
     QStringList buildRegisterExpressions(const QList<DataPoint>& registerList);
 
+    enum class PollState
+    {
+        Inactive,
+        WaitingForAdapter,
+        Active
+    };
+
     QList<DataPoint> _registerList;
     QStringList _pendingExpressions;
 
-    bool _bPollActive;
-    bool _bWaitingForAdapterReady;
+    PollState _pollState = PollState::Inactive;
     QMetaObject::Connection _adapterReadyConnection;
     QTimer* _pPollTimer;
     qint64 _lastPollStart;


### PR DESCRIPTION
Consolidate _bPollActive and _bWaitingForAdapterReady into a single
PollState enum (Inactive / WaitingForAdapter / Active). Invalid flag
combinations are now structurally impossible, and each state's
meaning is self-evident from its name. _adapterReadyConnection is
unchanged — it remains the correct idiom for cancellable connections.

https://claude.ai/code/session_01GSQeQ5if6UN8KQqy4vV4cw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal architectural improvements to state management systems to enhance code maintainability and reliability. No end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->