### PR TITLE
Add data point descriptions to expressions dialog

### DIFF
--- a/src/ProtocolAdapter/adaptermanager.cpp
+++ b/src/ProtocolAdapter/adaptermanager.cpp
@@ -21,6 +21,7 @@ AdapterManager::AdapterManager(SettingsModel* pSettingsModel, QObject* parent)
     connect(_pAdapterClient, &AdapterClient::readDataResult, this, &AdapterManager::readDataResult);
     connect(_pAdapterClient, &AdapterClient::buildExpressionResult, this, &AdapterManager::buildExpressionResult);
     connect(_pAdapterClient, &AdapterClient::expressionHelpResult, this, &AdapterManager::expressionHelpResult);
+    connect(_pAdapterClient, &AdapterClient::describeDataPointResult, this, &AdapterManager::describeDataPointResult);
     connect(_pAdapterClient, &AdapterClient::sessionStopped, this, &AdapterManager::sessionStopped);
     connect(_pAdapterClient, &AdapterClient::sessionError, this, &AdapterManager::sessionError);
     connect(_pAdapterClient, &AdapterClient::adapterReady, this, &AdapterManager::adapterReady);
@@ -80,6 +81,14 @@ bool AdapterManager::isAdapterIdle() const
 void AdapterManager::requestExpressionHelp()
 {
     _pAdapterClient->requestExpressionHelp();
+}
+
+/*! \brief Send an adapter.describeDataPoint request to retrieve a human-readable description of a data point expression.
+ * \param expression The data point expression string to describe.
+ */
+void AdapterManager::describeDataPoint(const QString& expression)
+{
+    _pAdapterClient->describeDataPoint(expression);
 }
 
 /*! \brief Send adapter.stop to pause polling and keep the adapter process alive. */

--- a/src/ProtocolAdapter/adaptermanager.cpp
+++ b/src/ProtocolAdapter/adaptermanager.cpp
@@ -83,7 +83,8 @@ void AdapterManager::requestExpressionHelp()
     _pAdapterClient->requestExpressionHelp();
 }
 
-/*! \brief Send an adapter.describeDataPoint request to retrieve a human-readable description of a data point expression.
+/*! \brief Send an adapter.describeDataPoint request to retrieve a human-readable description of a data point
+ * expression.
  * \param expression The data point expression string to describe.
  */
 void AdapterManager::describeDataPoint(const QString& expression)

--- a/src/ProtocolAdapter/adaptermanager.h
+++ b/src/ProtocolAdapter/adaptermanager.h
@@ -82,6 +82,16 @@ public:
     virtual void requestExpressionHelp();
 
     /*!
+     * \brief Send an adapter.describeDataPoint request to retrieve a human-readable description of a data point expression.
+     *
+     * Can be called when the adapter is in AWAITING_CONFIG or ACTIVE state.
+     * Emits describeDataPointResult() when the adapter responds.
+     *
+     * \param expression The data point expression string to describe.
+     */
+    virtual void describeDataPoint(const QString& expression);
+
+    /*!
      * \brief Route an adapter.diagnostic notification to the diagnostics log.
      *
      * Public for testability. Maps the adapter's level string to the appropriate
@@ -131,6 +141,12 @@ signals:
      * \param helpText HTML string describing expression syntax.
      */
     void expressionHelpResult(QString helpText);
+
+    /*!
+     * \brief Emitted when an adapter.describeDataPoint response has been received.
+     * \param result The full result object (valid, fields, description or error).
+     */
+    void describeDataPointResult(QJsonObject result);
 
 private slots:
     void onDescribeResult(const QJsonObject& description);

--- a/src/ProtocolAdapter/adaptermanager.h
+++ b/src/ProtocolAdapter/adaptermanager.h
@@ -82,7 +82,8 @@ public:
     virtual void requestExpressionHelp();
 
     /*!
-     * \brief Send an adapter.describeDataPoint request to retrieve a human-readable description of a data point expression.
+     * \brief Send an adapter.describeDataPoint request to retrieve a human-readable description of a data point
+     * expression.
      *
      * Can be called when the adapter is in AWAITING_CONFIG or ACTIVE state.
      * Emits describeDataPointResult() when the adapter responds.

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -166,7 +166,7 @@ void ExpressionsDialog::startNextDescribe()
 
 void ExpressionsDialog::handleDescribeDataPointResult(const QJsonObject& result)
 {
-    if (_nextDescribeRow >= _pUi->tblExpressionInput->rowCount())
+    if (_nextDescribeRow >= _pendingDescribeAddresses.size())
     {
         return;
     }

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -27,10 +27,10 @@ ExpressionsDialog::ExpressionsDialog(GraphDataModel* pGraphDataModel,
 
     if (_pAdapterManager != nullptr)
     {
-        connect(_pAdapterManager, &AdapterManager::expressionHelpResult,
-                this, &ExpressionsDialog::handleExpressionHelpResult);
-        connect(_pAdapterManager, &AdapterManager::describeDataPointResult,
-                this, &ExpressionsDialog::handleDescribeDataPointResult);
+        connect(_pAdapterManager, &AdapterManager::expressionHelpResult, this,
+                &ExpressionsDialog::handleExpressionHelpResult);
+        connect(_pAdapterManager, &AdapterManager::describeDataPointResult, this,
+                &ExpressionsDialog::handleDescribeDataPointResult);
         _pAdapterManager->requestExpressionHelp();
     }
 
@@ -66,7 +66,7 @@ void ExpressionsDialog::handleExpressionChange()
 
         /* Save current test values keyed by address (Qt::UserRole), not displayed text */
         QMap<QString, QString> testValueMap;
-        for(qint32 idx = 0; idx < _pUi->tblExpressionInput->rowCount(); idx++)
+        for (qint32 idx = 0; idx < _pUi->tblExpressionInput->rowCount(); idx++)
         {
             QTableWidgetItem* pAddrItem = _pUi->tblExpressionInput->item(idx, 0);
             QTableWidgetItem* pValueItem = _pUi->tblExpressionInput->item(idx, 1);
@@ -85,7 +85,7 @@ void ExpressionsDialog::handleExpressionChange()
         _pUi->tblExpressionInput->setRowCount(descriptions.size());
         _pHighlighter->setExpressionErrorPosition(-1);
 
-        for(qint32 idx = 0; idx < descriptions.size(); idx++)
+        for (qint32 idx = 0; idx < descriptions.size(); idx++)
         {
             QTableWidgetItem* pRegItem = new QTableWidgetItem(descriptions[idx]);
             pRegItem->setFlags(pRegItem->flags() & ~Qt::ItemIsEditable);
@@ -114,19 +114,19 @@ void ExpressionsDialog::handleInputChange()
         const auto white = QColorConstants::White;
 
         ResultDoubleList results;
-        for(qint32 idx = 0; idx < _pUi->tblExpressionInput->rowCount(); idx++)
+        for (qint32 idx = 0; idx < _pUi->tblExpressionInput->rowCount(); idx++)
         {
             QTableWidgetItem* pValueItem = _pUi->tblExpressionInput->item(idx, 1);
             QString valueStr = pValueItem->text();
             bool bOk = false;
             double value = valueStr.toDouble(&bOk);
-            results.append(ResultDouble(value, bOk ? State::SUCCESS: State::INVALID));
+            results.append(ResultDouble(value, bOk ? State::SUCCESS : State::INVALID));
 
             /* Avoid recursive signal/slots calling */
             _pUi->tblExpressionInput->blockSignals(true);
 
-            pValueItem->setBackground(bOk ? white: lightRed);
-            pValueItem->setToolTip(bOk ? QString(): QStringLiteral("Not a valid number"));
+            pValueItem->setBackground(bOk ? white : lightRed);
+            pValueItem->setToolTip(bOk ? QString() : QStringLiteral("Not a valid number"));
 
             _pUi->tblExpressionInput->blockSignals(false);
         }

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -88,7 +88,7 @@ void ExpressionsDialog::handleExpressionChange()
             pRegItem->setData(Qt::UserRole, addresses[idx]);
             _pUi->tblExpressionInput->setItem(idx, 0, pRegItem);
 
-            QString testVal = testValueMap.contains(addresses[idx]) ? testValueMap[addresses[idx]] : "0";
+            QString testVal = testValueMap.value(addresses[idx], QStringLiteral("0"));
             _pUi->tblExpressionInput->setItem(idx, 1, new QTableWidgetItem(testVal));
         }
 

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -29,8 +29,6 @@ ExpressionsDialog::ExpressionsDialog(GraphDataModel* pGraphDataModel,
     {
         connect(_pAdapterManager, &AdapterManager::expressionHelpResult, this,
                 &ExpressionsDialog::handleExpressionHelpResult);
-        connect(_pAdapterManager, &AdapterManager::describeDataPointResult, this,
-                &ExpressionsDialog::handleDescribeDataPointResult);
         _pAdapterManager->requestExpressionHelp();
     }
 
@@ -100,6 +98,11 @@ void ExpressionsDialog::handleExpressionChange()
 
         _pendingDescribeAddresses = addresses;
         _nextDescribeRow = 0;
+        if (_pAdapterManager != nullptr)
+        {
+            QObject::disconnect(_pAdapterManager, &AdapterManager::describeDataPointResult, this,
+                                &ExpressionsDialog::handleDescribeDataPointResult);
+        }
         startNextDescribe();
 
         handleInputChange();
@@ -156,6 +159,8 @@ void ExpressionsDialog::startNextDescribe()
 {
     if (_pAdapterManager != nullptr && _nextDescribeRow < _pendingDescribeAddresses.size())
     {
+        connect(_pAdapterManager, &AdapterManager::describeDataPointResult, this,
+                &ExpressionsDialog::handleDescribeDataPointResult, Qt::SingleShotConnection);
         _pAdapterManager->describeDataPoint(_pendingDescribeAddresses[_nextDescribeRow]);
     }
 }
@@ -168,9 +173,10 @@ void ExpressionsDialog::handleDescribeDataPointResult(const QJsonObject& result)
     }
 
     QString description = result["description"].toString();
-    if (!description.isEmpty())
+    QTableWidgetItem* pItem = _pUi->tblExpressionInput->item(_nextDescribeRow, 0);
+    if (pItem != nullptr && !description.isEmpty())
     {
-        _pUi->tblExpressionInput->item(_nextDescribeRow, 0)->setText(description);
+        pItem->setText(description);
     }
 
     _nextDescribeRow++;

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -29,6 +29,8 @@ ExpressionsDialog::ExpressionsDialog(GraphDataModel* pGraphDataModel,
     {
         connect(_pAdapterManager, &AdapterManager::expressionHelpResult,
                 this, &ExpressionsDialog::handleExpressionHelpResult);
+        connect(_pAdapterManager, &AdapterManager::describeDataPointResult,
+                this, &ExpressionsDialog::handleDescribeDataPointResult);
         _pAdapterManager->requestExpressionHelp();
     }
 
@@ -62,18 +64,22 @@ void ExpressionsDialog::handleExpressionChange()
     {
         _expressionChecker.setExpression(expression);
 
-        /* Save current test values */
+        /* Save current test values keyed by address (Qt::UserRole), not displayed text */
         QMap<QString, QString> testValueMap;
         for(qint32 idx = 0; idx < _pUi->tblExpressionInput->rowCount(); idx++)
         {
-            QString descr = _pUi->tblExpressionInput->item(idx, 0)->text();
-            QString value = _pUi->tblExpressionInput->item(idx, 1)->text();
-
-            testValueMap.insert(descr, value);
+            QTableWidgetItem* pAddrItem = _pUi->tblExpressionInput->item(idx, 0);
+            QTableWidgetItem* pValueItem = _pUi->tblExpressionInput->item(idx, 1);
+            if (pAddrItem != nullptr && pValueItem != nullptr)
+            {
+                testValueMap.insert(pAddrItem->data(Qt::UserRole).toString(), pValueItem->text());
+            }
         }
 
         QStringList descriptions;
+        QStringList addresses;
         _expressionChecker.descriptions(descriptions);
+        _expressionChecker.addresses(addresses);
 
         _bUpdating = true;
         _pUi->tblExpressionInput->setRowCount(descriptions.size());
@@ -81,17 +87,20 @@ void ExpressionsDialog::handleExpressionChange()
 
         for(qint32 idx = 0; idx < descriptions.size(); idx++)
         {
-            QString regDescr = descriptions[idx];
-            QTableWidgetItem *newRegisterDescr = new QTableWidgetItem(regDescr);
-            newRegisterDescr->setFlags(newRegisterDescr->flags() & ~Qt::ItemIsEditable);
-            _pUi->tblExpressionInput->setItem(idx, 0, newRegisterDescr);
+            QTableWidgetItem* pRegItem = new QTableWidgetItem(descriptions[idx]);
+            pRegItem->setFlags(pRegItem->flags() & ~Qt::ItemIsEditable);
+            pRegItem->setData(Qt::UserRole, addresses[idx]);
+            _pUi->tblExpressionInput->setItem(idx, 0, pRegItem);
 
-            QString testVal = testValueMap.contains(regDescr) ? testValueMap[regDescr]: "0";
-            QTableWidgetItem *newRegisterValue = new QTableWidgetItem(testVal);
-            _pUi->tblExpressionInput->setItem(idx, 1, newRegisterValue);
+            QString testVal = testValueMap.contains(addresses[idx]) ? testValueMap[addresses[idx]] : "0";
+            _pUi->tblExpressionInput->setItem(idx, 1, new QTableWidgetItem(testVal));
         }
 
         _bUpdating = false;
+
+        _pendingDescribeAddresses = addresses;
+        _nextDescribeRow = 0;
+        startNextDescribe();
 
         handleInputChange();
     }
@@ -141,6 +150,31 @@ void ExpressionsDialog::handleAccept()
 void ExpressionsDialog::handleExpressionHelpResult(const QString& helpText)
 {
     _pUi->lblInfo->setText(helpText);
+}
+
+void ExpressionsDialog::startNextDescribe()
+{
+    if (_pAdapterManager != nullptr && _nextDescribeRow < _pendingDescribeAddresses.size())
+    {
+        _pAdapterManager->describeDataPoint(_pendingDescribeAddresses[_nextDescribeRow]);
+    }
+}
+
+void ExpressionsDialog::handleDescribeDataPointResult(const QJsonObject& result)
+{
+    if (_nextDescribeRow >= _pUi->tblExpressionInput->rowCount())
+    {
+        return;
+    }
+
+    QString description = result["description"].toString();
+    if (!description.isEmpty())
+    {
+        _pUi->tblExpressionInput->item(_nextDescribeRow, 0)->setText(description);
+    }
+
+    _nextDescribeRow++;
+    startNextDescribe();
 }
 
 void ExpressionsDialog::handleResultReady(bool valid)

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -74,10 +74,8 @@ void ExpressionsDialog::handleExpressionChange()
             }
         }
 
-        QStringList descriptions;
-        QStringList addresses;
-        _expressionChecker.descriptions(descriptions);
-        _expressionChecker.addresses(addresses);
+        QStringList descriptions = _expressionChecker.descriptions();
+        QStringList addresses = _expressionChecker.addresses();
 
         _bUpdating = true;
         _pUi->tblExpressionInput->setRowCount(descriptions.size());
@@ -157,7 +155,8 @@ void ExpressionsDialog::handleExpressionHelpResult(const QString& helpText)
 
 void ExpressionsDialog::startNextDescribe()
 {
-    if (_pAdapterManager != nullptr && _nextDescribeRow < _pendingDescribeAddresses.size())
+    if (_pAdapterManager != nullptr && !_pAdapterManager->isAdapterIdle() &&
+        _nextDescribeRow < _pendingDescribeAddresses.size())
     {
         connect(_pAdapterManager, &AdapterManager::describeDataPointResult, this,
                 &ExpressionsDialog::handleDescribeDataPointResult, Qt::SingleShotConnection);

--- a/src/dialogs/expressionsdialog.h
+++ b/src/dialogs/expressionsdialog.h
@@ -5,6 +5,8 @@
 #include "util/expressionchecker.h"
 
 #include <QDialog>
+#include <QJsonObject>
+#include <QStringList>
 
 /* Forward declarations */
 class AdapterManager;
@@ -32,8 +34,11 @@ private slots:
     void handleAccept();
     void handleResultReady(bool valid);
     void handleExpressionHelpResult(const QString& helpText);
+    void handleDescribeDataPointResult(const QJsonObject& result);
 
 private:
+    void startNextDescribe();
+
     Ui::ExpressionsDialog* _pUi;
 
     qint32 _graphIdx;
@@ -45,6 +50,9 @@ private:
     ExpressionHighlighting* _pHighlighter;
 
     bool _bUpdating;
+
+    QStringList _pendingDescribeAddresses;
+    qint32 _nextDescribeRow = 0;
 };
 
 #endif // EXPRESSIONSDIALOG_H

--- a/src/util/expressionchecker.cpp
+++ b/src/util/expressionchecker.cpp
@@ -16,9 +16,11 @@ void ExpressionChecker::setExpression(QString expr)
 
     _expectedDeviceIdList.clear();
     _descriptions.clear();
+    _addresses.clear();
     for (DataPoint const& reg : std::as_const(registerList))
     {
         _descriptions.append(reg.description());
+        _addresses.append(reg.address());
 
         if (!_expectedDeviceIdList.contains(reg.deviceId()))
         {
@@ -42,6 +44,11 @@ QString ExpressionChecker::expression(void)
 void ExpressionChecker::descriptions(QStringList& descr)
 {
     descr = _descriptions;
+}
+
+void ExpressionChecker::addresses(QStringList& addrs)
+{
+    addrs = _addresses;
 }
 
 qsizetype ExpressionChecker::requiredValueCount()

--- a/src/util/expressionchecker.cpp
+++ b/src/util/expressionchecker.cpp
@@ -5,7 +5,7 @@ ExpressionChecker::ExpressionChecker(QObject* parent) : QObject(parent)
 {
 }
 
-void ExpressionChecker::setExpression(QString expr)
+void ExpressionChecker::setExpression(const QString& expr)
 {
     _localGraphDataModel.clear();
     _localGraphDataModel.add();
@@ -41,14 +41,14 @@ QString ExpressionChecker::expression(void)
     }
 }
 
-void ExpressionChecker::descriptions(QStringList& descr)
+QStringList ExpressionChecker::descriptions() const
 {
-    descr = _descriptions;
+    return _descriptions;
 }
 
-void ExpressionChecker::addresses(QStringList& addrs)
+QStringList ExpressionChecker::addresses() const
 {
-    addrs = _addresses;
+    return _addresses;
 }
 
 qsizetype ExpressionChecker::requiredValueCount()

--- a/src/util/expressionchecker.h
+++ b/src/util/expressionchecker.h
@@ -11,11 +11,11 @@ class ExpressionChecker : public QObject
 public:
     explicit ExpressionChecker(QObject* parent = nullptr);
 
-    void setExpression(QString expr);
+    void setExpression(const QString& expr);
 
     QString expression(void);
-    void descriptions(QStringList& descr);
-    void addresses(QStringList& addrs);
+    QStringList descriptions() const;
+    QStringList addresses() const;
     qsizetype requiredValueCount();
 
     bool checkForDevices(QList<deviceId_t> const& deviceIdList);

--- a/src/util/expressionchecker.h
+++ b/src/util/expressionchecker.h
@@ -15,6 +15,7 @@ public:
 
     QString expression(void);
     void descriptions(QStringList& descr);
+    void addresses(QStringList& addrs);
     qsizetype requiredValueCount();
 
     bool checkForDevices(QList<deviceId_t> const& deviceIdList);
@@ -38,6 +39,7 @@ private:
     QList<deviceId_t> _expectedDeviceIdList;
 
     QStringList _descriptions;
+    QStringList _addresses;
 
     bool _bValid;
     double _result;

--- a/tests/dialogs/CMakeLists.txt
+++ b/tests/dialogs/CMakeLists.txt
@@ -3,3 +3,4 @@
 add_xtest(tst_addregisterwidget)
 add_xtest(tst_adaptersettings)
 add_xtest(tst_adapterdevicesettings)
+add_xtest(tst_expressionsdialog tst_expressionsdialog.h)

--- a/tests/dialogs/tst_expressionsdialog.cpp
+++ b/tests/dialogs/tst_expressionsdialog.cpp
@@ -1,0 +1,93 @@
+
+#include "tst_expressionsdialog.h"
+
+#include "dialogs/expressionsdialog.h"
+#include "models/graphdata.h"
+#include "models/graphdatamodel.h"
+
+#include <QPlainTextEdit>
+#include <QTableWidget>
+#include <QTest>
+
+void TestExpressionsDialog::init()
+{
+    _pGraphDataModel = new GraphDataModel(this);
+    _pGraphDataModel->add(GraphData());
+    _pMockAdapterManager = new MockAdapterManager(this);
+    _pDialog = new ExpressionsDialog(_pGraphDataModel, 0, _pMockAdapterManager);
+}
+
+void TestExpressionsDialog::cleanup()
+{
+    delete _pDialog;
+    _pDialog = nullptr;
+}
+
+void TestExpressionsDialog::describeDispatch_singleAddress()
+{
+    auto* pEdit = _pDialog->findChild<QPlainTextEdit*>("lineExpression");
+    QVERIFY(pEdit != nullptr);
+
+    pEdit->setPlainText(QStringLiteral("${40001}"));
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+    QCOMPARE(_pMockAdapterManager->describeCalls[0], QStringLiteral("${40001}"));
+
+    _pMockAdapterManager->injectDescribeResult(QStringLiteral("Holding register 40001"));
+
+    auto* pTable = _pDialog->findChild<QTableWidget*>("tblExpressionInput");
+    QVERIFY(pTable != nullptr);
+    QCOMPARE(pTable->item(0, 0)->text(), QStringLiteral("Holding register 40001"));
+
+    /* No further describe calls after last address */
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+}
+
+void TestExpressionsDialog::describeDispatch_multipleAddresses()
+{
+    auto* pEdit = _pDialog->findChild<QPlainTextEdit*>("lineExpression");
+    QVERIFY(pEdit != nullptr);
+
+    pEdit->setPlainText(QStringLiteral("${40001} + ${40002}"));
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+    QCOMPARE(_pMockAdapterManager->describeCalls[0], QStringLiteral("${40001}"));
+
+    _pMockAdapterManager->injectDescribeResult(QStringLiteral("Reg 1"));
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 2);
+    QCOMPARE(_pMockAdapterManager->describeCalls[1], QStringLiteral("${40002}"));
+
+    _pMockAdapterManager->injectDescribeResult(QStringLiteral("Reg 2"));
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 2);
+
+    auto* pTable = _pDialog->findChild<QTableWidget*>("tblExpressionInput");
+    QVERIFY(pTable != nullptr);
+    QCOMPARE(pTable->item(0, 0)->text(), QStringLiteral("Reg 1"));
+    QCOMPARE(pTable->item(1, 0)->text(), QStringLiteral("Reg 2"));
+}
+
+void TestExpressionsDialog::describeDispatch_abortsOnExpressionChange()
+{
+    auto* pEdit = _pDialog->findChild<QPlainTextEdit*>("lineExpression");
+    QVERIFY(pEdit != nullptr);
+
+    /* Start describe sequence for expression A */
+    pEdit->setPlainText(QStringLiteral("${40001}"));
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+
+    /* Expression changes before result arrives: starts fresh sequence for B */
+    pEdit->setPlainText(QStringLiteral("${40002}"));
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 2);
+    QCOMPARE(_pMockAdapterManager->describeCalls[1], QStringLiteral("${40002}"));
+
+    /* Result arrives — must apply to expression B's row only */
+    _pMockAdapterManager->injectDescribeResult(QStringLiteral("Reg 2"));
+
+    auto* pTable = _pDialog->findChild<QTableWidget*>("tblExpressionInput");
+    QVERIFY(pTable != nullptr);
+    QCOMPARE(pTable->item(0, 0)->text(), QStringLiteral("Reg 2"));
+
+    /* Stale A connection was cancelled — no further calls triggered */
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 2);
+}
+
+QTEST_MAIN(TestExpressionsDialog)
+#include "tst_expressionsdialog.moc"

--- a/tests/dialogs/tst_expressionsdialog.h
+++ b/tests/dialogs/tst_expressionsdialog.h
@@ -1,0 +1,71 @@
+
+#ifndef TST_EXPRESSIONSDIALOG_H
+#define TST_EXPRESSIONSDIALOG_H
+
+#include "ProtocolAdapter/adaptermanager.h"
+
+#include <QJsonObject>
+#include <QObject>
+
+/*!
+ * \brief Test double for AdapterManager.
+ *
+ * Captures describeDataPoint() calls and provides an inject helper to simulate
+ * the adapter.describeDataPoint response without a real adapter process.
+ */
+class MockAdapterManager : public AdapterManager
+{
+    Q_OBJECT
+
+public:
+    explicit MockAdapterManager(QObject* parent = nullptr) : AdapterManager(nullptr, parent)
+    {
+    }
+
+    void describeDataPoint(const QString& address) override
+    {
+        describeCalls.append(address);
+    }
+
+    void requestExpressionHelp() override
+    {
+    }
+
+    bool isAdapterIdle() const override
+    {
+        return false;
+    }
+
+    //! Simulate the adapter returning a description for the last requested data point.
+    void injectDescribeResult(const QString& description)
+    {
+        QJsonObject result;
+        result["description"] = description;
+        emit describeDataPointResult(result);
+    }
+
+    QStringList describeCalls;
+};
+
+class GraphDataModel;
+class ExpressionsDialog;
+
+class TestExpressionsDialog : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    void describeDispatch_singleAddress();
+    void describeDispatch_multipleAddresses();
+    void describeDispatch_abortsOnExpressionChange();
+
+private:
+    GraphDataModel* _pGraphDataModel{ nullptr };
+    MockAdapterManager* _pMockAdapterManager{ nullptr };
+    ExpressionsDialog* _pDialog{ nullptr };
+};
+
+#endif // TST_EXPRESSIONSDIALOG_H

--- a/tests/util/tst_expressionchecker.cpp
+++ b/tests/util/tst_expressionchecker.cpp
@@ -25,8 +25,7 @@ void TestExpressionChecker::dataIsPrimed()
     checker.setExpression(expr);
     QCOMPARE(checker.expression(), expr);
 
-    QStringList descriptions;
-    checker.descriptions(descriptions);
+    QStringList descriptions = checker.descriptions();
     auto expDescriptions = QStringList() << "${40001}, device id 1"
                                          << "${40002}, device id 1";
     QCOMPARE(descriptions, expDescriptions);
@@ -40,8 +39,7 @@ void TestExpressionChecker::addressesMatchExpression()
 
     checker.setExpression("${40001} + ${40002}");
 
-    QStringList addrs;
-    checker.addresses(addrs);
+    QStringList addrs = checker.addresses();
     auto expAddresses = QStringList() << "${40001}" << "${40002}";
     QCOMPARE(addrs, expAddresses);
 }

--- a/tests/util/tst_expressionchecker.cpp
+++ b/tests/util/tst_expressionchecker.cpp
@@ -34,6 +34,18 @@ void TestExpressionChecker::dataIsPrimed()
     QCOMPARE(checker.requiredValueCount(), 2);
 }
 
+void TestExpressionChecker::addressesMatchExpression()
+{
+    ExpressionChecker checker;
+
+    checker.setExpression("${40001} + ${40002}");
+
+    QStringList addrs;
+    checker.addresses(addrs);
+    auto expAddresses = QStringList() << "${40001}" << "${40002}";
+    QCOMPARE(addrs, expAddresses);
+}
+
 void TestExpressionChecker::expressionIsValid()
 {
     ExpressionChecker checker;

--- a/tests/util/tst_expressionchecker.h
+++ b/tests/util/tst_expressionchecker.h
@@ -1,10 +1,10 @@
 
 #include <QObject>
 
-class TestExpressionChecker: public QObject
+class TestExpressionChecker : public QObject
 {
     Q_OBJECT
-    
+
 private slots:
     void init();
     void cleanup();
@@ -19,5 +19,4 @@ private slots:
     void checkForDevices_missing();
 
 private:
-
 };

--- a/tests/util/tst_expressionchecker.h
+++ b/tests/util/tst_expressionchecker.h
@@ -10,6 +10,7 @@ private slots:
     void cleanup();
 
     void dataIsPrimed();
+    void addressesMatchExpression();
     void expressionIsValid();
     void expressionHasSyntaxError();
     void valueErrorIsNotSyntaxError();


### PR DESCRIPTION
## Summary
This PR enhances the Expressions Dialog to display human-readable descriptions for data points by fetching them from the adapter via the `describeDataPoint` API.

## Key Changes

- **ExpressionChecker**: Added tracking of data point addresses alongside descriptions
  - New `addresses()` method to retrieve the list of addresses from the current expression
  - Addresses are now stored in `_addresses` list parallel to `_descriptions`

- **ExpressionsDialog**: Implemented asynchronous description fetching
  - Modified table to store addresses in `Qt::UserRole` while displaying descriptions
  - Added `handleDescribeDataPointResult()` slot to process description responses
  - Added `startNextDescribe()` to sequentially request descriptions for each data point
  - Test values are now keyed by address (not display text) to persist across description updates
  - Improved null pointer safety when accessing table items

- **AdapterManager**: Added `describeDataPoint()` method
  - New public method to send `adapter.describeDataPoint` requests
  - New `describeDataPointResult` signal to emit responses
  - Properly connected to underlying AdapterClient

- **Tests**: Added `addressesMatchExpression()` test case
  - Verifies that extracted addresses match the expression format

## Implementation Details

The solution uses sequential requests to avoid overwhelming the adapter. When an expression changes, the dialog extracts all required data point addresses and sequentially requests their descriptions. As each description arrives, the corresponding table cell is updated with the human-readable text while preserving the address in the item's user role for internal reference.

https://claude.ai/code/session_012bR4wmwJsWPPNgu66YdbUg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve human‑readable descriptions for data‑point expressions.
  * Expression editor now automatically fetches and displays descriptions for all register addresses and preserves user‑entered test values when expressions change.
  * Expression checker exposes register addresses so callers can inspect extracted addresses.

* **Tests**
  * Added unit tests for address extraction and dialog behaviour validating describe dispatch, ordering and abort-on-change.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModbusScope/ModbusScope/pull/449)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->