### PR TITLE
Skip SonarQube signature verification in CI workflow

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -71,6 +71,7 @@ jobs:
     - name: SonarQube Scan
       uses: SonarSource/sonarqube-scan-action@v8.0
       with:
+        skipSignatureVerification: true
         # Consult https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/ for more information and options
         args: >
           --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"


### PR DESCRIPTION
## Summary
Updated the SonarQube scan action configuration to skip signature verification during the code quality check in the CI workflow.

## Key Changes
- Added `skipSignatureVerification: true` parameter to the SonarSource/sonarqube-scan-action@v8.0 step in the code quality workflow

## Details
This change disables signature verification for the SonarQube scanner action, which can help avoid verification-related failures in CI environments where signature validation may not be necessary or could cause pipeline interruptions.

https://claude.ai/code/session_01Miru87GPnaUYRQaL6x5WSZ