### PR TITLE
Adapter config defaults

### DIFF
--- a/src/models/adapterdata.cpp
+++ b/src/models/adapterdata.cpp
@@ -121,9 +121,17 @@ int AdapterData::maxDevicesFromSchema() const
 
 QJsonObject AdapterData::effectiveConfig() const
 {
-    if (_hasStoredConfig)
+    if (!_hasStoredConfig)
     {
-        return _currentConfig;
+        return _defaults;
     }
-    return _defaults;
+
+    /* Use defaults as the base so that keys added to the adapter after a project file was
+     * saved (e.g. 'general') are automatically filled in rather than left absent. */
+    QJsonObject result = _defaults;
+    for (auto it = _currentConfig.constBegin(); it != _currentConfig.constEnd(); ++it)
+    {
+        result[it.key()] = it.value();
+    }
+    return result;
 }

--- a/src/models/adapterdata.cpp
+++ b/src/models/adapterdata.cpp
@@ -127,7 +127,12 @@ QJsonObject AdapterData::effectiveConfig() const
     }
 
     /* Use defaults as the base so that keys added to the adapter after a project file was
-     * saved (e.g. 'general') are automatically filled in rather than left absent. */
+     * saved (e.g. 'general') are automatically filled in rather than left absent.
+     * This is a shallow merge: each top-level key in _currentConfig replaces the
+     * corresponding key in result entirely. Nested objects are not merged — if a stored
+     * key holds a QJsonObject, the whole sub-object is taken from _currentConfig and none
+     * of the default's nested keys are backfilled. A recursive merge would be needed if
+     * per-key deep backfilling is ever required (see result/_currentConfig/_defaults here). */
     QJsonObject result = _defaults;
     for (auto it = _currentConfig.constBegin(); it != _currentConfig.constEnd(); ++it)
     {

--- a/tests/models/tst_adapterdata.cpp
+++ b/tests/models/tst_adapterdata.cpp
@@ -132,7 +132,7 @@ void TestAdapterData::effectiveConfigFillsMissingKeysFromDefaults()
 
     QJsonObject defaults;
     defaults["general"] = QJsonObject();
-    defaults["connections"] = QJsonArray();
+    defaults["connections"] = QJsonArray{ QStringLiteral("default_connection") };
 
     QJsonObject describeResult;
     describeResult["name"] = "testAdapter";
@@ -141,7 +141,7 @@ void TestAdapterData::effectiveConfigFillsMissingKeysFromDefaults()
 
     /* Stored config from an old project file: missing the "general" key */
     QJsonObject storedConfig;
-    storedConfig["connections"] = QJsonArray();
+    storedConfig["connections"] = QJsonArray{ QStringLiteral("stored_connection") };
     data.setCurrentConfig(storedConfig);
     data.setHasStoredConfig(true);
 
@@ -149,8 +149,8 @@ void TestAdapterData::effectiveConfigFillsMissingKeysFromDefaults()
 
     /* "general" must be filled in from defaults */
     QVERIFY(config.value("general").isObject());
-    /* "connections" from stored config is preserved */
-    QVERIFY(config.value("connections").isArray());
+    /* "connections" must come from the stored config, not from defaults */
+    QCOMPARE(config.value("connections").toArray(), QJsonArray{ QStringLiteral("stored_connection") });
 }
 
 void TestAdapterData::settingsModelAdapterDataCreatesEntry()

--- a/tests/models/tst_adapterdata.cpp
+++ b/tests/models/tst_adapterdata.cpp
@@ -126,6 +126,33 @@ void TestAdapterData::effectiveConfigReturnsStoredConfig()
     QCOMPARE(config["setting"].toString(), QStringLiteral("stored_value"));
 }
 
+void TestAdapterData::effectiveConfigFillsMissingKeysFromDefaults()
+{
+    AdapterData data;
+
+    QJsonObject defaults;
+    defaults["general"] = QJsonObject();
+    defaults["connections"] = QJsonArray();
+
+    QJsonObject describeResult;
+    describeResult["name"] = "testAdapter";
+    describeResult["defaults"] = defaults;
+    data.updateFromDescribe(describeResult);
+
+    /* Stored config from an old project file: missing the "general" key */
+    QJsonObject storedConfig;
+    storedConfig["connections"] = QJsonArray();
+    data.setCurrentConfig(storedConfig);
+    data.setHasStoredConfig(true);
+
+    QJsonObject config = data.effectiveConfig();
+
+    /* "general" must be filled in from defaults */
+    QVERIFY(config.value("general").isObject());
+    /* "connections" from stored config is preserved */
+    QVERIFY(config.value("connections").isArray());
+}
+
 void TestAdapterData::settingsModelAdapterDataCreatesEntry()
 {
     SettingsModel model;

--- a/tests/models/tst_adapterdata.h
+++ b/tests/models/tst_adapterdata.h
@@ -16,6 +16,7 @@ private slots:
     void updateFromDescribeMissingFields();
     void effectiveConfigReturnsDefaults();
     void effectiveConfigReturnsStoredConfig();
+    void effectiveConfigFillsMissingKeysFromDefaults();
 
     void settingsModelAdapterDataCreatesEntry();
     void settingsModelAdapterIds();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling when loading stored settings from previous versions: missing top-level defaults are now backfilled while stored values are preserved. Note: nested objects are replaced rather than deep-merged.

* **Tests**
  * Added test coverage to verify configuration backfilling behaviour for older saved settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModbusScope/ModbusScope/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->