### PR TITLE
Fix sample point highlighting with event-driven approach

### DIFF
--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -55,8 +55,7 @@ GraphView::GraphView(GuiModel* pGuiModel,
      * */
     _pPlot->setMultiSelectModifier(Qt::ShiftModifier);
 
-    // Samples are enabled
-    _bEnableSampleHighlight = true;
+    _bCurrentHighlightState = false;
 
     // Add layer to move graph in front
     _pPlot->addLayer("topMain", _pPlot->layer("main"), QCustomPlot::limAbove);
@@ -69,7 +68,8 @@ GraphView::GraphView(GuiModel* pGuiModel,
     connect(_pPlot, &ScopePlot::mouseRelease, this, &GraphView::mouseRelease);
     connect(_pPlot, &ScopePlot::mouseWheel, this, &GraphView::mouseWheel);
     connect(_pPlot, &ScopePlot::mouseMove, this, &GraphView::mouseMove);
-    connect(_pPlot, &ScopePlot::beforeReplot, this, &GraphView::enableSamplePoints);
+    connect(_pPlot->xAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
+            &GraphView::handleSamplePoints);
 
     _pGraphScale = new GraphScale(_pGuiModel, _pPlot, this);
     _pGraphViewZoom = new GraphViewZoom(_pGuiModel, _pPlot, this);
@@ -172,8 +172,7 @@ void GraphView::updateTooltip()
 
 void GraphView::enableSamplePoints()
 {
-    _bEnableSampleHighlight = _pGuiModel->highlightSamples();
-    _pPlot->replot();
+    handleSamplePoints();
 }
 
 void GraphView::clearGraph(const quint32 graphIdx)
@@ -633,42 +632,43 @@ void GraphView::handleSamplePoints()
 {
     bool bHighlight = false;
 
-    if (_bEnableSampleHighlight)
+    if (_pGuiModel->highlightSamples() && _pPlot->graphCount() > 0 && graphDataSize() > 0)
     {
-        if (_pPlot->graphCount() > 0 && (graphDataSize() > 0))
+        QCPRange axisRange = _pPlot->xAxis->range();
+
+        auto lowerBoundIt = _pPlot->graph(0)->data()->findBegin(axisRange.lower, false);
+        auto upperBoundIt = _pPlot->graph(0)->data()->findBegin(axisRange.upper);
+
+        const int pointCount = upperBoundIt - lowerBoundIt;
+
+        /* Get size in pixels */
+        const double sizePx =
+          _pPlot->xAxis->coordToPixel(upperBoundIt->key) - _pPlot->xAxis->coordToPixel(lowerBoundIt->key);
+
+        /* Calculate number of pixels per point */
+        double nrOfPixelsPerPoint;
+
+        if (lowerBoundIt != upperBoundIt)
         {
-            QCPRange axisRange = _pPlot->xAxis->range();
+            nrOfPixelsPerPoint = sizePx / qAbs(pointCount);
+        }
+        else
+        {
+            nrOfPixelsPerPoint = sizePx;
+        }
 
-            auto lowerBoundIt = _pPlot->graph(0)->data()->findBegin(axisRange.lower, false);
-            auto upperBoundIt = _pPlot->graph(0)->data()->findBegin(axisRange.upper);
-
-            const int pointCount = upperBoundIt - lowerBoundIt;
-
-            /* Get size in pixels */
-            const double sizePx =
-              _pPlot->xAxis->coordToPixel(upperBoundIt->key) - _pPlot->xAxis->coordToPixel(lowerBoundIt->key);
-
-            /* Calculate number of pixels per point */
-            double nrOfPixelsPerPoint;
-
-            if (lowerBoundIt != upperBoundIt)
-            {
-                nrOfPixelsPerPoint = sizePx / qAbs(pointCount);
-            }
-            else
-            {
-                nrOfPixelsPerPoint = sizePx;
-            }
-
-            if (nrOfPixelsPerPoint > _cPixelPerPointThreshold)
-            {
-                bHighlight = true;
-            }
+        if (nrOfPixelsPerPoint > _cPixelPerPointThreshold)
+        {
+            bHighlight = true;
         }
     }
 
-    /* TODO: add hysteresis to highlight sample points */
-    highlightSamples(bHighlight);
+    if (bHighlight != _bCurrentHighlightState)
+    {
+        _bCurrentHighlightState = bHighlight;
+        highlightSamples(bHighlight);
+        _pPlot->replot();
+    }
 }
 
 void GraphView::highlightSamples(bool bState)

--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -638,28 +638,32 @@ void GraphView::handleSamplePoints()
 
         auto lowerBoundIt = _pPlot->graph(0)->data()->findBegin(axisRange.lower, false);
         auto upperBoundIt = _pPlot->graph(0)->data()->findBegin(axisRange.upper);
+        const auto endIt = _pPlot->graph(0)->data()->constEnd();
 
-        const int pointCount = upperBoundIt - lowerBoundIt;
-
-        /* Get size in pixels */
-        const double sizePx =
-          _pPlot->xAxis->coordToPixel(upperBoundIt->key) - _pPlot->xAxis->coordToPixel(lowerBoundIt->key);
-
-        /* Calculate number of pixels per point */
-        double nrOfPixelsPerPoint;
-
-        if (lowerBoundIt != upperBoundIt)
+        if (lowerBoundIt != endIt)
         {
-            nrOfPixelsPerPoint = sizePx / qAbs(pointCount);
-        }
-        else
-        {
-            nrOfPixelsPerPoint = sizePx;
-        }
+            const int pointCount = upperBoundIt - lowerBoundIt;
 
-        if (nrOfPixelsPerPoint > _cPixelPerPointThreshold)
-        {
-            bHighlight = true;
+            /* Get size in pixels */
+            const double sizePx =
+              _pPlot->xAxis->coordToPixel(upperBoundIt->key) - _pPlot->xAxis->coordToPixel(lowerBoundIt->key);
+
+            /* Calculate number of pixels per point */
+            double nrOfPixelsPerPoint;
+
+            if (lowerBoundIt != upperBoundIt)
+            {
+                nrOfPixelsPerPoint = sizePx / qAbs(pointCount);
+            }
+            else
+            {
+                nrOfPixelsPerPoint = sizePx;
+            }
+
+            if (nrOfPixelsPerPoint > _cPixelPerPointThreshold)
+            {
+                bHighlight = true;
+            }
         }
     }
 

--- a/src/graphview/graphview.h
+++ b/src/graphview/graphview.h
@@ -88,7 +88,7 @@ private:
     GraphDataModel* _pGraphDataModel;
     CommunicationStatsModel* _pCommunicationStatsModel;
     ScopePlot* _pPlot;
-    bool _bEnableSampleHighlight;
+    bool _bCurrentHighlightState;
 
     GraphScale* _pGraphScale;
     GraphViewZoom* _pGraphViewZoom;


### PR DESCRIPTION
Connect to xAxis::rangeChanged instead of beforeReplot, so the highlight calculation only runs when the visible range changes. Track the last applied state and only call replot() on transitions, avoiding redundant replots on every pan/zoom event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved sample-point highlighting to respond to x-axis range changes, initialise highlighting to a deterministic baseline, and avoid redundant redraws by only updating when the visible interval necessitates a change.
  * Simplified enablement flow so highlighting updates are handled centrally, reducing unnecessary processing and improving responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModbusScope/ModbusScope/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->