### PR TITLE
Add first install quick start dialog

### DIFF
--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "dialogs/aboutdialog.h"
 #include "dialogs/diagnosticdialog.h"
 #include "dialogs/importmbcdialog.h"
+#include "dialogs/quickstartdialog.h"
 #include "dialogs/registerdialog.h"
 #include "dialogs/settingsdialog.h"
 #include "dialogs/ui_mainwindow.h"
@@ -33,6 +34,8 @@
 #include "util/versiondownloader.h"
 
 #include <QDateTime>
+#include <QSettings>
+#include <QTimer>
 
 using GuiState = GuiModel::GuiState;
 
@@ -108,6 +111,7 @@ MainWindow::MainWindow(QStringList cmdArguments,
     connect(_pUi->actionSaveProjectFile, &QAction::triggered, _pProjectFileHandler,
             &ProjectFileHandler::saveProjectFile);
     connect(_pUi->actionAbout, &QAction::triggered, this, &MainWindow::showAbout);
+    connect(_pUi->actionQuickStart, &QAction::triggered, this, &MainWindow::showQuickStartDialog);
     connect(_pUi->actionOnlineDocumentation, &QAction::triggered, this, &MainWindow::openOnlineDoc);
     connect(_pUi->actionUpdateAvailable, &QAction::triggered, this, &MainWindow::openUpdateUrl);
     connect(_pUi->actionHighlightSamplePoints, &QAction::toggled, _pGuiModel, &GuiModel::setHighlightSamples);
@@ -226,6 +230,9 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     _pAdapterPoll->initAdapter();
 
+    // Defer until after the main window is shown — avoids a modal dialog blocking constructor completion
+    QTimer::singleShot(0, this, &MainWindow::showFirstInstallDialogIfNeeded);
+
 #if 0
     //Debugging
     _pGraphDataModel->add();
@@ -334,6 +341,23 @@ void MainWindow::showAbout()
     AboutDialog aboutDialog(_pUpdateNotify, _pSettingsModel, this);
 
     aboutDialog.exec();
+}
+
+void MainWindow::showQuickStartDialog()
+{
+    QuickStartDialog dialog(this);
+    dialog.exec();
+}
+
+void MainWindow::showFirstInstallDialogIfNeeded()
+{
+    static const QString cFirstInstallKey = QStringLiteral("general/firstInstallShown");
+    QSettings settings;
+    if (!settings.contains(cFirstInstallKey))
+    {
+        settings.setValue(cFirstInstallKey, true);
+        showQuickStartDialog();
+    }
 }
 
 void MainWindow::openOnlineDoc()

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -26,6 +26,7 @@ class SettingsModel;
 class DataParserModel;
 class DiagnosticDialog;
 class NotesDock;
+class QuickStartDialog;
 class GuiModel;
 class GraphView;
 class MarkerInfo;
@@ -107,10 +108,12 @@ private slots:
 
     void showVersionUpdate(UpdateNotify::UpdateState result);
     void onRegisterDataReady(const ResultDoubleList& results);
+    void showQuickStartDialog();
 
 private:
     void setAxisToAuto();
     void showRegisterDialog();
+    void showFirstInstallDialogIfNeeded();
     void handleCommandLineArguments(QStringList cmdArguments);
     void handleFileOpen(QString filename);
 

--- a/src/dialogs/mainwindow.ui
+++ b/src/dialogs/mainwindow.ui
@@ -85,6 +85,8 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
+    <addaction name="actionQuickStart"/>
+    <addaction name="separator"/>
     <addaction name="actionUpdateAvailable"/>
     <addaction name="actionAbout"/>
     <addaction name="actionOnlineDocumentation"/>
@@ -509,6 +511,11 @@
    </property>
    <property name="text">
     <string>&amp;Settings...</string>
+   </property>
+  </action>
+  <action name="actionQuickStart">
+   <property name="text">
+    <string>&amp;Quick Start...</string>
    </property>
   </action>
  </widget>

--- a/src/dialogs/quickstartdialog.cpp
+++ b/src/dialogs/quickstartdialog.cpp
@@ -1,8 +1,7 @@
 #include "quickstartdialog.h"
 #include "ui_quickstartdialog.h"
 
-QuickStartDialog::QuickStartDialog(QWidget* parent)
-    : QDialog(parent), _pUi(new Ui::QuickStartDialog)
+QuickStartDialog::QuickStartDialog(QWidget* parent) : QDialog(parent), _pUi(new Ui::QuickStartDialog)
 {
     _pUi->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);

--- a/src/dialogs/quickstartdialog.cpp
+++ b/src/dialogs/quickstartdialog.cpp
@@ -1,6 +1,8 @@
 #include "quickstartdialog.h"
 #include "ui_quickstartdialog.h"
 
+#include <QPushButton>
+
 QuickStartDialog::QuickStartDialog(QWidget* parent) : QDialog(parent), _pUi(new Ui::QuickStartDialog)
 {
     _pUi->setupUi(this);
@@ -8,6 +10,14 @@ QuickStartDialog::QuickStartDialog(QWidget* parent) : QDialog(parent), _pUi(new 
     // Qt uic 6.8.3 bug: generates invalid setContentsMargins(20) (single-int overload)
     // when all four margins are equal. Set margins manually until fixed upstream.
     setContentsMargins(20, 20, 20, 20);
+
+    const QString badgeStyle = QString("QLabel { background-color: %1; color: white; border-radius: 12px; }")
+                                 .arg(palette().color(QPalette::Highlight).name());
+    _pUi->lblStep1Nr->setStyleSheet(badgeStyle);
+    _pUi->lblStep2Nr->setStyleSheet(badgeStyle);
+    _pUi->lblStep3Nr->setStyleSheet(badgeStyle);
+
+    connect(_pUi->btnClose, &QPushButton::clicked, this, &QDialog::reject);
 }
 
 QuickStartDialog::~QuickStartDialog()

--- a/src/dialogs/quickstartdialog.cpp
+++ b/src/dialogs/quickstartdialog.cpp
@@ -1,0 +1,14 @@
+#include "quickstartdialog.h"
+#include "ui_quickstartdialog.h"
+
+QuickStartDialog::QuickStartDialog(QWidget* parent)
+    : QDialog(parent), _pUi(new Ui::QuickStartDialog)
+{
+    _pUi->setupUi(this);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+}
+
+QuickStartDialog::~QuickStartDialog()
+{
+    delete _pUi;
+}

--- a/src/dialogs/quickstartdialog.cpp
+++ b/src/dialogs/quickstartdialog.cpp
@@ -5,6 +5,9 @@ QuickStartDialog::QuickStartDialog(QWidget* parent) : QDialog(parent), _pUi(new 
 {
     _pUi->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    // Qt uic 6.8.3 bug: generates invalid setContentsMargins(20) (single-int overload)
+    // when all four margins are equal. Set margins manually until fixed upstream.
+    setContentsMargins(20, 20, 20, 20);
 }
 
 QuickStartDialog::~QuickStartDialog()

--- a/src/dialogs/quickstartdialog.h
+++ b/src/dialogs/quickstartdialog.h
@@ -1,0 +1,22 @@
+#ifndef QUICKSTARTDIALOG_H
+#define QUICKSTARTDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class QuickStartDialog;
+}
+
+class QuickStartDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit QuickStartDialog(QWidget* parent = nullptr);
+    ~QuickStartDialog();
+
+private:
+    Ui::QuickStartDialog* _pUi;
+};
+
+#endif // QUICKSTARTDIALOG_H

--- a/src/dialogs/quickstartdialog.ui
+++ b/src/dialogs/quickstartdialog.ui
@@ -6,15 +6,9 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>380</height>
+    <width>513</width>
+    <height>300</height>
    </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>500</width>
-    <height>380</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Quick Start</string>
@@ -23,8 +17,17 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>12</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayoutHeader">
+     <property name="bottomMargin">
+      <number>20</number>
+     </property>
      <item>
       <spacer name="horizontalSpacerLeft">
        <property name="orientation">
@@ -39,35 +42,51 @@
       </spacer>
      </item>
      <item>
+      <widget class="QLabel" name="lblIcon">
+       <property name="minimumSize">
+        <size>
+         <width>48</width>
+         <height>48</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>48</width>
+         <height>48</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../../resources.qrc">:/about_images/resources/icon/icon-128x128.png</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacerIconText">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>12</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <layout class="QVBoxLayout" name="verticalLayoutHeader">
-       <item>
-        <widget class="QLabel" name="lblIcon">
-         <property name="minimumSize">
-          <size>
-           <width>64</width>
-           <height>64</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>64</width>
-           <height>64</height>
-          </size>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="pixmap">
-          <pixmap resource="../../resources.qrc">:/about_images/resources/icon/icon-128x128.png</pixmap>
-         </property>
-         <property name="scaledContents">
-          <bool>true</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
        <item>
         <widget class="QLabel" name="lblTitle">
          <property name="font">
@@ -79,8 +98,17 @@
          <property name="text">
           <string>Welcome to ModbusScope</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblSubtitle">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Get started in 3 steps</string>
          </property>
         </widget>
        </item>
@@ -102,185 +130,207 @@
     </layout>
    </item>
    <item>
-    <spacer name="verticalSpacerTop">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
+    <widget class="QFrame" name="separator">
+     <property name="frameShape">
+      <enum>QFrame::Shape::HLine</enum>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayoutStep1">
-     <item>
-      <widget class="QLabel" name="lblStep1Nr">
-       <property name="minimumSize">
-        <size>
-         <width>24</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>24</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>1.</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="lblStep1">
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open &lt;span style=&quot; font-weight:700;&quot;&gt;Project → Settings&lt;/span&gt; to configure your connection and device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayoutStep2">
-     <item>
-      <widget class="QLabel" name="lblStep2Nr">
-       <property name="minimumSize">
-        <size>
-         <width>24</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>24</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>2.</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="lblStep2">
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open &lt;span style=&quot; font-weight:700;&quot;&gt;Project → Registers&lt;/span&gt; to add the Modbus registers you want to monitor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayoutStep3">
-     <item>
-      <widget class="QLabel" name="lblStep3Nr">
-       <property name="minimumSize">
-        <size>
-         <width>24</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>24</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>3.</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="lblStep3">
-       <property name="text">
-        <string>Press the &lt;b&gt;Play&lt;/b&gt; button to start reading data from your device.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacerBottom">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Close</set>
+     <property name="frameShadow">
+      <enum>QFrame::Shadow::Sunken</enum>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayoutSteps">
+     <property name="topMargin">
+      <number>20</number>
+     </property>
+     <property name="bottomMargin">
+      <number>20</number>
+     </property>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayoutStep1">
+       <item>
+        <widget class="QLabel" name="lblStep1Nr">
+         <property name="minimumSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>1</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblStep1">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open &lt;span style=&quot; font-weight:700;&quot;&gt;Project → Settings&lt;/span&gt; to configure your connection and device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayoutStep2">
+       <item>
+        <widget class="QLabel" name="lblStep2Nr">
+         <property name="minimumSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>2</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblStep2">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open &lt;span style=&quot; font-weight:700;&quot;&gt;Project → Registers&lt;/span&gt; to add the Modbus registers you want to monitor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayoutStep3">
+       <item>
+        <widget class="QLabel" name="lblStep3Nr">
+         <property name="minimumSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>3</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblStep3">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Press the &lt;b&gt;Play&lt;/b&gt; button to start reading data from your device.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutClose">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacerCloseLeft">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnClose">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacerCloseRight">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <resources>
   <include location="../../resources.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QuickStartDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>354</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>374</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/dialogs/quickstartdialog.ui
+++ b/src/dialogs/quickstartdialog.ui
@@ -23,12 +23,6 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="contentsMargins">
-    <number>20</number>
-    <number>20</number>
-    <number>20</number>
-    <number>20</number>
-   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayoutHeader">
      <item>

--- a/src/dialogs/quickstartdialog.ui
+++ b/src/dialogs/quickstartdialog.ui
@@ -70,17 +70,17 @@
        </item>
        <item>
         <widget class="QLabel" name="lblTitle">
-         <property name="text">
-          <string>Welcome to ModbusScope</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
-         </property>
          <property name="font">
           <font>
            <pointsize>14</pointsize>
            <bold>true</bold>
           </font>
+         </property>
+         <property name="text">
+          <string>Welcome to ModbusScope</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -130,13 +130,13 @@
          <height>16777215</height>
         </size>
        </property>
-       <property name="text">
-        <string>1.</string>
-       </property>
        <property name="font">
         <font>
          <bold>true</bold>
         </font>
+       </property>
+       <property name="text">
+        <string>1.</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignmentFlag::AlignTop</set>
@@ -146,7 +146,7 @@
      <item>
       <widget class="QLabel" name="lblStep1">
        <property name="text">
-        <string>Open &lt;b&gt;Tools → Settings&lt;/b&gt; to configure your connection and device.</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open &lt;span style=&quot; font-weight:700;&quot;&gt;Project → Settings&lt;/span&gt; to configure your connection and device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -171,13 +171,13 @@
          <height>16777215</height>
         </size>
        </property>
-       <property name="text">
-        <string>2.</string>
-       </property>
        <property name="font">
         <font>
          <bold>true</bold>
         </font>
+       </property>
+       <property name="text">
+        <string>2.</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignmentFlag::AlignTop</set>
@@ -187,7 +187,7 @@
      <item>
       <widget class="QLabel" name="lblStep2">
        <property name="text">
-        <string>Open &lt;b&gt;Tools → Registers&lt;/b&gt; to add the Modbus registers you want to monitor.</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open &lt;span style=&quot; font-weight:700;&quot;&gt;Project → Registers&lt;/span&gt; to add the Modbus registers you want to monitor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -212,13 +212,13 @@
          <height>16777215</height>
         </size>
        </property>
-       <property name="text">
-        <string>3.</string>
-       </property>
        <property name="font">
         <font>
          <bold>true</bold>
         </font>
+       </property>
+       <property name="text">
+        <string>3.</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignmentFlag::AlignTop</set>

--- a/src/dialogs/quickstartdialog.ui
+++ b/src/dialogs/quickstartdialog.ui
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QuickStartDialog</class>
+ <widget class="QDialog" name="QuickStartDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>380</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>380</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Quick Start</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="contentsMargins">
+    <number>20</number>
+    <number>20</number>
+    <number>20</number>
+    <number>20</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutHeader">
+     <item>
+      <spacer name="horizontalSpacerLeft">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayoutHeader">
+       <item>
+        <widget class="QLabel" name="lblIcon">
+         <property name="minimumSize">
+          <size>
+           <width>64</width>
+           <height>64</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>64</width>
+           <height>64</height>
+          </size>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="pixmap">
+          <pixmap resource="../../resources.qrc">:/about_images/resources/icon/icon-128x128.png</pixmap>
+         </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblTitle">
+         <property name="text">
+          <string>Welcome to ModbusScope</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>14</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacerRight">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacerTop">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutStep1">
+     <item>
+      <widget class="QLabel" name="lblStep1Nr">
+       <property name="minimumSize">
+        <size>
+         <width>24</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>24</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>1.</string>
+       </property>
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblStep1">
+       <property name="text">
+        <string>Open &lt;b&gt;Tools → Settings&lt;/b&gt; to configure your connection and device.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutStep2">
+     <item>
+      <widget class="QLabel" name="lblStep2Nr">
+       <property name="minimumSize">
+        <size>
+         <width>24</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>24</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>2.</string>
+       </property>
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblStep2">
+       <property name="text">
+        <string>Open &lt;b&gt;Tools → Registers&lt;/b&gt; to add the Modbus registers you want to monitor.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutStep3">
+     <item>
+      <widget class="QLabel" name="lblStep3Nr">
+       <property name="minimumSize">
+        <size>
+         <width>24</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>24</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>3.</string>
+       </property>
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblStep3">
+       <property name="text">
+        <string>Press the &lt;b&gt;Play&lt;/b&gt; button to start reading data from your device.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacerBottom">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../resources.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QuickStartDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>354</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>374</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Shows a welcome dialog once on first launch explaining the 3-step
workflow: configure connection/device, add registers, start polling.
Accessible any time via Help → Quick Start. First-install state is
stored in QSettings under "general/firstInstallShown".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Quick Start" item in the Help menu to open a concise getting-started dialog.
  * A welcome Quick Start dialog now appears automatically on first launch (shown once) to guide new users through initial setup.
  * Dialog presents a three-step walkthrough with numbered badges, header icon and title, fixed layout, and a single Close button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->