### PR TITLE
Fix crash when highlighting non-consecutive active register

### DIFF
--- a/src/customwidgets/legend.cpp
+++ b/src/customwidgets/legend.cpp
@@ -379,13 +379,15 @@ void Legend::showAll()
     }
 }
 
-void Legend::handleSelectedGraphChanged(const qint32 activeGraphIdx)
+void Legend::handleSelectedGraphChanged(const qint32 graphIdx)
 {
+    const qint32 activeIdx = (graphIdx == -1) ? -1 : _pGraphDataModel->convertToActiveGraphIndex(graphIdx);
+
     for (int idx = 0; idx < _pLegendTable->rowCount(); idx++)
     {
         QFont itemFont = _pLegendTable->item(idx, cColummnValue)->font();
 
-        if (idx == activeGraphIdx)
+        if (idx == activeIdx)
         {
             itemFont.setBold(true);
         }
@@ -422,7 +424,7 @@ void Legend::cellDoubleClicked(int row, int column)
 {
     if (column == cColummnColor)
     {
-        if (row != -1)
+        if ((row != -1) && (row < _pGraphDataModel->activeCount()))
         {
             const qint32 graphIdx = _pGraphDataModel->convertToGraphIndex(static_cast<quint32>(row));
             if (_pGraphDataModel->isVisible(graphIdx))
@@ -439,7 +441,7 @@ void Legend::cellDoubleClicked(int row, int column)
     }
     else if (column == cColummnAxis)
     {
-        if (row != -1)
+        if ((row != -1) && (row < _pGraphDataModel->activeCount()))
         {
             const qint32 graphIdx = _pGraphDataModel->convertToGraphIndex(static_cast<quint32>(row));
             if (_pGraphDataModel->isVisible(graphIdx))
@@ -465,7 +467,7 @@ void Legend::cellClicked(int row, int column)
 
     _clickTimer.stop();
 
-    if ((row != -1) && (row < _pGraphDataModel->size()))
+    if ((row != -1) && (row < _pGraphDataModel->activeCount()))
     {
         const qint32 graphIdx = _pGraphDataModel->convertToGraphIndex(row);
         qint32 toSelectGraph = (_pGraphDataModel->selectedGraph() != graphIdx) ? graphIdx : -1;

--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -306,11 +306,11 @@ void GraphView::changeGraphAxis(const quint32 graphIdx)
     }
 }
 
-void GraphView::changeSelectedGraph(const qint32 activeGraphIdx)
+void GraphView::changeSelectedGraph(const qint32 graphIdx)
 {
     QList<QCPGraph*> selectedGraphs = _pPlot->selectedGraphs();
 
-    if (activeGraphIdx == -1)
+    if (graphIdx == -1)
     {
         for (QCPGraph* selectedGraph : std::as_const(selectedGraphs))
         {
@@ -319,6 +319,12 @@ void GraphView::changeSelectedGraph(const qint32 activeGraphIdx)
     }
     else
     {
+        const qint32 activeGraphIdx = _pGraphDataModel->convertToActiveGraphIndex(static_cast<quint32>(graphIdx));
+        if (activeGraphIdx == -1)
+        {
+            return;
+        }
+
         auto graph = _pPlot->graph(activeGraphIdx);
         const bool bAlreadySelected = selectedGraphs.contains(graph);
 
@@ -562,13 +568,23 @@ void GraphView::handleSelectionChanged(bool selected)
     {
         QCPGraph* pGraph = qobject_cast<QCPGraph*>(QObject::sender());
         const qint32 activeIdx = getActiveGraphIndex(pGraph);
-        const qint32 graphIdx = _pGraphDataModel->convertToGraphIndex(activeIdx);
-        _pGraphDataModel->setSelectedGraph(graphIdx);
+        if (activeIdx == -1)
+        {
+            _pGraphDataModel->setSelectedGraph(-1);
+        }
+        else
+        {
+            const qint32 graphIdx = _pGraphDataModel->convertToGraphIndex(static_cast<quint32>(activeIdx));
+            _pGraphDataModel->setSelectedGraph(graphIdx);
+        }
     }
     else
     {
         _pGraphDataModel->setSelectedGraph(-1);
     }
+
+    const qint32 selectedGraph = _pGraphDataModel->selectedGraph();
+    const qint32 selectedActiveIdx = (selectedGraph == -1) ? -1 : _pGraphDataModel->convertToActiveGraphIndex(selectedGraph);
 
     for (qint32 idx = 0; idx < _pPlot->graphCount(); idx++)
     {
@@ -577,7 +593,7 @@ void GraphView::handleSelectionChanged(bool selected)
         QColor normalPen = QColor(baseColor.red(), baseColor.green(), baseColor.blue(), 255);
         QColor transparentPen = QColor(baseColor.red(), baseColor.green(), baseColor.blue(), 16);
 
-        if ((_pGraphDataModel->selectedGraph() == -1) || (idx == _pGraphDataModel->selectedGraph()))
+        if ((selectedActiveIdx == -1) || (idx == selectedActiveIdx))
         {
             graphPen.setColor(normalPen);
         }

--- a/tests/models/tst_graphdatastore.cpp
+++ b/tests/models/tst_graphdatastore.cpp
@@ -321,6 +321,24 @@ void TestGraphDataStore::setSelectedGraphEmitsSignal()
     QCOMPARE(store.selectedGraph(), 0);
 }
 
+void TestGraphDataStore::setSelectedGraphOnThirdRegisterWithMiddleInactiveEmitsGraphIndex()
+{
+    GraphDataStore store;
+    store.insertGraphData(makeGraph("A", "${h0}", true));
+    store.insertGraphData(makeGraph("B", "${h1}", false));
+    store.insertGraphData(makeGraph("C", "${h2}", true));
+
+    QSignalSpy spy(&store, &GraphDataStore::selectedGraphChanged);
+    store.setSelectedGraph(2);
+
+    // signal must carry graph index (2), not the active index (1)
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).toInt(), 2);
+    QCOMPARE(store.selectedGraph(), 2);
+    // and the active index for graph 2 must be 1, not 2
+    QCOMPARE(store.convertToActiveGraphIndex(2), 1);
+}
+
 void TestGraphDataStore::setSelectedGraphOnInvisibleGraphIsIgnored()
 {
     GraphDataStore store;

--- a/tests/models/tst_graphdatastore.h
+++ b/tests/models/tst_graphdatastore.h
@@ -33,6 +33,7 @@ private slots:
     void insertInactiveGraphDoesNotIncreaseActiveCount();
     void setActiveNoopDoesNotEmitSignal();
     void setSelectedGraphEmitsSignal();
+    void setSelectedGraphOnThirdRegisterWithMiddleInactiveEmitsGraphIndex();
     void setSelectedGraphOnInvisibleGraphIsIgnored();
     void setVisibleTrueEmitsSignal();
     void setVisibleFalseEmitsSignal();


### PR DESCRIPTION
When 3 registers exist with only the first and third enabled,
clicking the third graph in the legend crashed because
selectedGraphChanged emits a graph index (register index) but
changeSelectedGraph and handleSelectedGraphChanged were treating
it as an active graph index, causing _pPlot->graph(2) to be
called on a plot with only 2 graphs (valid indices 0–1).

- changeSelectedGraph: convert graphIdx→activeIdx via
  convertToActiveGraphIndex before indexing into the plot; return
  early if the graph is not active
- handleSelectionChanged: guard against activeIdx==-1 before
  calling convertToGraphIndex; use explicit quint32 cast;
  compute selectedActiveIdx for correct pen-color comparison
- handleSelectedGraphChanged: convert received graphIdx to active
  table-row index before bolding the legend row
- cellClicked / cellDoubleClicked: bound row against activeCount()
  instead of size() so the active-index lookup is always in range

Add test setSelectedGraphOnThirdRegisterWithMiddleInactiveEmitsGraphIndex
to document that selectedGraphChanged carries a graph index, not
an active index, and that convertToActiveGraphIndex must be used
by callers.

https://claude.ai/code/session_01RQ7fQhUygLjohZYCx8rXBK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed legend item styling when selecting graphs with inactive items.
  * Improved graph selection highlighting to correctly handle scenarios with inactive graphs.

* **Tests**
  * Added test coverage for graph selection scenarios with inactive graphs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModbusScope/ModbusScope/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->