### PR TITLE
Add empty state label to graph area when no registers are configured

### DIFF
--- a/src/customwidgets/overlaylabel.cpp
+++ b/src/customwidgets/overlaylabel.cpp
@@ -31,7 +31,10 @@ OverlayLabel::OverlayLabel(const QString& text, QWidget* pParent, QObject* paren
  */
 void OverlayLabel::setVisible(bool visible)
 {
-    _pLabel->setVisible(visible);
+    if (_pLabel)
+    {
+        _pLabel->setVisible(visible);
+    }
 }
 
 /*!
@@ -41,7 +44,10 @@ bool OverlayLabel::eventFilter(QObject* watched, QEvent* event)
 {
     if (!_pTargetWidget.isNull() && watched == _pTargetWidget && event->type() == QEvent::Resize)
     {
-        _pLabel->resize(_pTargetWidget->size());
+        if (_pLabel)
+        {
+            _pLabel->resize(_pTargetWidget->size());
+        }
     }
     return QObject::eventFilter(watched, event);
 }

--- a/src/customwidgets/overlaylabel.cpp
+++ b/src/customwidgets/overlaylabel.cpp
@@ -1,0 +1,47 @@
+#include "overlaylabel.h"
+
+#include <QEvent>
+#include <QLabel>
+#include <QWidget>
+
+/*!
+ * \brief Constructs an OverlayLabel centered over \a pParent.
+ *
+ * \param text     The message to display.
+ * \param pParent  The widget to overlay; owns the label as a child.
+ * \param parent   QObject parent for memory management.
+ */
+OverlayLabel::OverlayLabel(const QString& text, QWidget* pParent, QObject* parent)
+    : QObject(parent), _pTargetWidget(pParent), _pLabel(new QLabel(text, pParent))
+{
+    Q_ASSERT(pParent != nullptr);
+
+    _pLabel->setAlignment(Qt::AlignCenter);
+    _pLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
+    _pLabel->setStyleSheet("color: #888888; font-size: 13px;");
+    _pLabel->resize(pParent->size());
+    _pLabel->setVisible(false);
+
+    pParent->installEventFilter(this);
+}
+
+/*!
+ * \brief Shows or hides the overlay label.
+ * \param visible Pass \c true to show, \c false to hide.
+ */
+void OverlayLabel::setVisible(bool visible)
+{
+    _pLabel->setVisible(visible);
+}
+
+/*!
+ * \brief Resizes the overlay label to match the target widget on resize events.
+ */
+bool OverlayLabel::eventFilter(QObject* watched, QEvent* event)
+{
+    if (!_pTargetWidget.isNull() && watched == _pTargetWidget && event->type() == QEvent::Resize)
+    {
+        _pLabel->resize(_pTargetWidget->size());
+    }
+    return QObject::eventFilter(watched, event);
+}

--- a/src/customwidgets/overlaylabel.cpp
+++ b/src/customwidgets/overlaylabel.cpp
@@ -8,11 +8,10 @@
  * \brief Constructs an OverlayLabel centered over \a pParent.
  *
  * \param text     The message to display.
- * \param pParent  The widget to overlay; owns the label as a child.
- * \param parent   QObject parent for memory management.
+ * \param pParent  The widget to overlay; owns both the label and this object as children.
  */
-OverlayLabel::OverlayLabel(const QString& text, QWidget* pParent, QObject* parent)
-    : QObject(parent), _pTargetWidget(pParent), _pLabel(new QLabel(text, pParent))
+OverlayLabel::OverlayLabel(const QString& text, QWidget* pParent)
+    : QObject(pParent), _pTargetWidget(pParent), _pLabel(new QLabel(text, pParent))
 {
     Q_ASSERT(pParent != nullptr);
 

--- a/src/customwidgets/overlaylabel.h
+++ b/src/customwidgets/overlaylabel.h
@@ -20,7 +20,7 @@ protected:
 
 private:
     QPointer<QWidget> _pTargetWidget;
-    QLabel* _pLabel;
+    QPointer<QLabel> _pLabel;
 };
 
 #endif // OVERLAYLABEL_H

--- a/src/customwidgets/overlaylabel.h
+++ b/src/customwidgets/overlaylabel.h
@@ -1,0 +1,26 @@
+#ifndef OVERLAYLABEL_H
+#define OVERLAYLABEL_H
+
+#include <QObject>
+#include <QPointer>
+
+class QLabel;
+class QWidget;
+
+class OverlayLabel : public QObject
+{
+    Q_OBJECT
+public:
+    explicit OverlayLabel(const QString& text, QWidget* pParent, QObject* parent = nullptr);
+
+    void setVisible(bool visible);
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    QPointer<QWidget> _pTargetWidget;
+    QLabel* _pLabel;
+};
+
+#endif // OVERLAYLABEL_H

--- a/src/customwidgets/overlaylabel.h
+++ b/src/customwidgets/overlaylabel.h
@@ -11,7 +11,7 @@ class OverlayLabel : public QObject
 {
     Q_OBJECT
 public:
-    explicit OverlayLabel(const QString& text, QWidget* pParent, QObject* parent = nullptr);
+    explicit OverlayLabel(const QString& text, QWidget* pParent);
 
     void setVisible(bool visible);
 

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -638,17 +638,17 @@ void MainWindow::rebuildGraphMenu()
     for (qint32 activeIdx = 0; activeIdx < activeGraphList.size(); activeIdx++)
     {
 
-        QString label = _pGraphDataModel->label(activeGraphList[activeIdx]);
+        QString label = _pGraphDataModel->label(activeGraphList.at(activeIdx));
         QAction* pShowHideAction = _pGraphShowHide->addAction(label);
 
         QPixmap pixmap(20, 5);
-        pixmap.fill(_pGraphDataModel->color(activeGraphList[activeIdx]));
+        pixmap.fill(_pGraphDataModel->color(activeGraphList.at(activeIdx)));
         QIcon icon = QIcon(pixmap);
 
         pShowHideAction->setData(QVariant::fromValue(ActiveIdx(activeIdx)));
         pShowHideAction->setIcon(icon);
         pShowHideAction->setCheckable(true);
-        pShowHideAction->setChecked(_pGraphDataModel->isVisible(activeGraphList[activeIdx]));
+        pShowHideAction->setChecked(_pGraphDataModel->isVisible(activeGraphList.at(activeIdx)));
 
         connect(pShowHideAction, &QAction::toggled, this, &MainWindow::menuShowHideGraphClicked);
     }

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -60,7 +60,7 @@ MainWindow::MainWindow(QStringList cmdArguments,
     QApplication::setStyle(QStyleFactory::create("Fusion"));
 
     _pOverlayLabel =
-      new OverlayLabel(tr("No registers configured — click Register Settings to add one"), _pUi->customPlot, this);
+      new OverlayLabel(tr("No registers configured — click Register Settings to add one"), _pUi->customPlot);
 
     _pDiagnosticDialog = new DiagnosticDialog(_pDiagnosticModel, this);
 

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -58,11 +58,11 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     QApplication::setStyle(QStyleFactory::create("Fusion"));
 
-    _pEmptyStateLabel = new QLabel("No registers configured — click Register Settings to add one", _pUi->customPlot);
+    _pEmptyStateLabel =
+      new QLabel(tr("No registers configured — click Register Settings to add one"), _pUi->customPlot);
     _pEmptyStateLabel->setAlignment(Qt::AlignCenter);
     _pEmptyStateLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     _pEmptyStateLabel->setStyleSheet("color: #888888; font-size: 13px;");
-    _pEmptyStateLabel->resize(_pUi->customPlot->size());
     _pUi->customPlot->installEventFilter(this);
 
     _pDiagnosticDialog = new DiagnosticDialog(_pDiagnosticModel, this);
@@ -147,6 +147,7 @@ MainWindow::MainWindow(QStringList cmdArguments,
     connect(_pGraphDataModel, &GraphDataModel::graphsAddData, this, &MainWindow::setAxisToAuto);
 
     connect(_pGraphDataModel, &GraphDataModel::activeChanged, this, &MainWindow::rebuildGraphMenu);
+    connect(_pGraphDataModel, &GraphDataModel::activeChanged, this, &MainWindow::handleGraphsCountChanged);
     connect(_pGraphDataModel, &GraphDataModel::activeChanged, _pGraphView, &GraphView::updateGraphs);
 
     connect(_pGraphDataModel, &GraphDataModel::colorChanged, this, &MainWindow::handleGraphColorChange);
@@ -636,7 +637,7 @@ void MainWindow::handleGraphsCountChanged()
     _pUi->actionZoom->setEnabled(bEnabled);
     _pUi->actionToggleMarkers->setEnabled(bEnabled);
 
-    _pEmptyStateLabel->setVisible(_pGraphDataModel->size() == 0);
+    _pEmptyStateLabel->setVisible(_pGraphDataModel->activeCount() == 0);
 }
 
 void MainWindow::rebuildGraphMenu()

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -143,7 +143,6 @@ MainWindow::MainWindow(QStringList cmdArguments,
     connect(_pGraphDataModel, &GraphDataModel::graphsAddData, _pGraphView, &GraphView::addData);
     connect(_pGraphDataModel, &GraphDataModel::graphsAddData, this, &MainWindow::setAxisToAuto);
 
-    connect(_pGraphDataModel, &GraphDataModel::activeChanged, this, &MainWindow::rebuildGraphMenu);
     connect(_pGraphDataModel, &GraphDataModel::activeChanged, this, &MainWindow::handleGraphsCountChanged);
     connect(_pGraphDataModel, &GraphDataModel::activeChanged, _pGraphView, &GraphView::updateGraphs);
 

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -58,6 +58,13 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     QApplication::setStyle(QStyleFactory::create("Fusion"));
 
+    _pEmptyStateLabel = new QLabel("No registers configured — click Register Settings to add one", _pUi->customPlot);
+    _pEmptyStateLabel->setAlignment(Qt::AlignCenter);
+    _pEmptyStateLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
+    _pEmptyStateLabel->setStyleSheet("color: #888888; font-size: 13px;");
+    _pEmptyStateLabel->resize(_pUi->customPlot->size());
+    _pUi->customPlot->installEventFilter(this);
+
     _pDiagnosticDialog = new DiagnosticDialog(_pDiagnosticModel, this);
 
     _pNotesDock = new NotesDock(_pNoteModel, _pGuiModel, this);
@@ -297,6 +304,15 @@ void MainWindow::closeEvent(QCloseEvent* event)
     {
         event->accept();
     }
+}
+
+bool MainWindow::eventFilter(QObject* watched, QEvent* event)
+{
+    if (watched == _pUi->customPlot && event->type() == QEvent::Resize)
+    {
+        _pEmptyStateLabel->resize(_pUi->customPlot->size());
+    }
+    return QMainWindow::eventFilter(watched, event);
 }
 
 void MainWindow::exitApplication()
@@ -619,6 +635,8 @@ void MainWindow::handleGraphsCountChanged()
     const bool bEnabled = !activeGraphList.isEmpty();
     _pUi->actionZoom->setEnabled(bEnabled);
     _pUi->actionToggleMarkers->setEnabled(bEnabled);
+
+    _pEmptyStateLabel->setVisible(_pGraphDataModel->size() == 0);
 }
 
 void MainWindow::rebuildGraphMenu()

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -5,6 +5,7 @@
 #include "customwidgets/markerinfo.h"
 #include "customwidgets/mostrecentmenu.h"
 #include "customwidgets/notesdock.h"
+#include "customwidgets/overlaylabel.h"
 #include "customwidgets/statusbar.h"
 #include "datahandling/graphdatahandler.h"
 #include "dialogs/aboutdialog.h"
@@ -58,12 +59,8 @@ MainWindow::MainWindow(QStringList cmdArguments,
 
     QApplication::setStyle(QStyleFactory::create("Fusion"));
 
-    _pEmptyStateLabel =
-      new QLabel(tr("No registers configured — click Register Settings to add one"), _pUi->customPlot);
-    _pEmptyStateLabel->setAlignment(Qt::AlignCenter);
-    _pEmptyStateLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
-    _pEmptyStateLabel->setStyleSheet("color: #888888; font-size: 13px;");
-    _pUi->customPlot->installEventFilter(this);
+    _pOverlayLabel =
+      new OverlayLabel(tr("No registers configured — click Register Settings to add one"), _pUi->customPlot, this);
 
     _pDiagnosticDialog = new DiagnosticDialog(_pDiagnosticModel, this);
 
@@ -305,15 +302,6 @@ void MainWindow::closeEvent(QCloseEvent* event)
     {
         event->accept();
     }
-}
-
-bool MainWindow::eventFilter(QObject* watched, QEvent* event)
-{
-    if (watched == _pUi->customPlot && event->type() == QEvent::Resize)
-    {
-        _pEmptyStateLabel->resize(_pUi->customPlot->size());
-    }
-    return QMainWindow::eventFilter(watched, event);
 }
 
 void MainWindow::exitApplication()
@@ -637,7 +625,7 @@ void MainWindow::handleGraphsCountChanged()
     _pUi->actionZoom->setEnabled(bEnabled);
     _pUi->actionToggleMarkers->setEnabled(bEnabled);
 
-    _pEmptyStateLabel->setVisible(_pGraphDataModel->activeCount() == 0);
+    _pOverlayLabel->setVisible(!bEnabled);
 }
 
 void MainWindow::rebuildGraphMenu()

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -56,10 +56,12 @@ public:
     ~MainWindow();
 
 protected:
-    void keyPressEvent(QKeyEvent* event);
-    void keyReleaseEvent(QKeyEvent* event);
-    void closeEvent(QCloseEvent* event);
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
     bool eventFilter(QObject* watched, QEvent* event) override;
+    void dragEnterEvent(QDragEnterEvent* e) override;
+    void dropEvent(QDropEvent* e) override;
 
 private slots:
 
@@ -101,8 +103,6 @@ private slots:
     void scaleWidgetUndocked(bool bFloat);
     void legendWidgetUndocked(bool bFloat);
     void showContextMenu(const QPoint& pos);
-    void dragEnterEvent(QDragEnterEvent* e);
-    void dropEvent(QDropEvent* e);
     void appFocusChanged(QWidget* old, QWidget* now);
     void updateDataFileNotes();
 

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -8,7 +8,6 @@
 #include "util/updatenotify.h"
 
 #include <QButtonGroup>
-#include <QLabel>
 #include <QListWidgetItem>
 #include <QMainWindow>
 #include <QMenu>
@@ -36,6 +35,7 @@ class Legend;
 class StatusBar;
 class ExpressionStatus;
 class MostRecentMenu;
+class OverlayLabel;
 class CommunicationStats;
 class CommunicationStatsModel;
 
@@ -59,7 +59,6 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
-    bool eventFilter(QObject* watched, QEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* e) override;
     void dropEvent(QDropEvent* e) override;
 
@@ -142,7 +141,7 @@ private:
     Legend* _pLegend;
     StatusBar* _pStatusBar;
 
-    QLabel* _pEmptyStateLabel;
+    OverlayLabel* _pOverlayLabel;
 
     QMenu _menuRightClick;
     QMenu* _pGraphShowHide;

--- a/src/dialogs/mainwindow.h
+++ b/src/dialogs/mainwindow.h
@@ -8,6 +8,7 @@
 #include "util/updatenotify.h"
 
 #include <QButtonGroup>
+#include <QLabel>
 #include <QListWidgetItem>
 #include <QMainWindow>
 #include <QMenu>
@@ -58,6 +59,7 @@ protected:
     void keyPressEvent(QKeyEvent* event);
     void keyReleaseEvent(QKeyEvent* event);
     void closeEvent(QCloseEvent* event);
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private slots:
 
@@ -139,6 +141,8 @@ private:
     MarkerInfo* _pMarkerInfo;
     Legend* _pLegend;
     StatusBar* _pStatusBar;
+
+    QLabel* _pEmptyStateLabel;
 
     QMenu _menuRightClick;
     QMenu* _pGraphShowHide;

--- a/tests/models/tst_graphdatamodel.cpp
+++ b/tests/models/tst_graphdatamodel.cpp
@@ -54,4 +54,31 @@ void TestGraphDataModel::setDefaultExpressionIgnoresEmptyString()
     QCOMPARE(model.expression(GraphIdx(0)), QStringLiteral("${i0}"));
 }
 
+void TestGraphDataModel::activeCountZeroWhenEmpty()
+{
+    GraphDataModel model;
+    QCOMPARE(model.activeCount(), 0);
+}
+
+void TestGraphDataModel::activeCountReflectsAddedRegisters()
+{
+    GraphDataModel model;
+    model.add();
+    QCOMPARE(model.activeCount(), 1);
+    model.add();
+    QCOMPARE(model.activeCount(), 2);
+}
+
+void TestGraphDataModel::activeCountZeroWhenAllDeactivated()
+{
+    /* Registers that exist but are inactive must not count — this is the condition
+       used to show the empty-state label in the graph area. */
+    GraphDataModel model;
+    model.add();
+    QCOMPARE(model.activeCount(), 1);
+
+    model.setActive(GraphIdx(0), false);
+    QCOMPARE(model.activeCount(), 0);
+}
+
 QTEST_GUILESS_MAIN(TestGraphDataModel)

--- a/tests/models/tst_graphdatamodel.h
+++ b/tests/models/tst_graphdatamodel.h
@@ -15,6 +15,10 @@ private slots:
     void addUsesCustomDefaultExpression();
     void setDefaultExpressionUpdatesSubsequentAdds();
     void setDefaultExpressionIgnoresEmptyString();
+
+    void activeCountZeroWhenEmpty();
+    void activeCountReflectsAddedRegisters();
+    void activeCountZeroWhenAllDeactivated();
 };
 
 #endif /* TST_GRAPHDATAMODEL_H */


### PR DESCRIPTION
Show "No registers configured — click Register Settings to add one"
centered over the plot widget when no registers are present. The label
resizes with the plot via an event filter and is transparent to mouse
events so the plot stays interactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Empty-state overlay label appears centred in the plot area when no registers or graph data are active. It ignores mouse input, auto-resizes with the plot, and its visibility updates as active graph count changes.

* **Tests**
  * Added unit tests verifying active graph counts: zero when empty, increments when registers are added, and returns to zero when all are deactivated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModbusScope/ModbusScope/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->