### PR TITLE
Exclude dummymodbusadapter from build and deployment artifacts

### DIFF
--- a/scripts/deploy_linux.sh
+++ b/scripts/deploy_linux.sh
@@ -5,9 +5,8 @@ set -ex
 cp resources/ModbusScope.desktop release/src/bin/linux/
 cp resources/icon/icon-256x256.png release/src/bin/linux/ModbusScope.png
 
-# Copy adapter binaries so linuxdeploy bundles them alongside the main executable
+# Copy modbusadapter so linuxdeploy bundles it alongside the main executable
 cp adapters/modbusadapter release/src/bin/linux/
-cp adapters/dummymodbusadapter release/src/bin/linux/
 
 cd release/src/bin/linux/
 

--- a/scripts/deploy_windows.bat
+++ b/scripts/deploy_windows.bat
@@ -14,24 +14,18 @@ mkdir %DEPLOY_DIR%
 copy modbusscope.exe %DEPLOY_DIR%
 IF ERRORLEVEL 1 GOTO errorHandling
 
-REM Copy adapter binaries into the flat deployment directory
+REM Copy adapter binary into the flat deployment directory
 copy %~dp0..\adapters\modbusadapter.exe %DEPLOY_DIR%
-IF ERRORLEVEL 1 GOTO errorHandling
-
-copy %~dp0..\adapters\dummymodbusadapter.exe %DEPLOY_DIR%
 IF ERRORLEVEL 1 GOTO errorHandling
 
 cd %DEPLOY_DIR%
 
-REM Run windeployqt on all three executables. Because they share the same Qt
+REM Run windeployqt on both executables. Because they share the same Qt
 REM version and output directory, DLLs are written once and cover all binaries.
 windeployqt.exe modbusscope.exe --compiler-runtime -verbose 2
 IF ERRORLEVEL 1 GOTO errorHandling
 
 windeployqt.exe modbusadapter.exe -verbose 2
-IF ERRORLEVEL 1 GOTO errorHandling
-
-windeployqt.exe dummymodbusadapter.exe -verbose 2
 IF ERRORLEVEL 1 GOTO errorHandling
 
 REM Add OpenSSL dll's

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,13 +64,12 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 # Reset GUI type to blank
 set(GUI_TYPE "")
 
-# Copy adapter binaries next to the main executable so they can be found at runtime
+# Copy modbusadapter next to the main executable so it can be found at runtime
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:modbusadapter>
-        $<TARGET_FILE:dummymodbusadapter>
         $<TARGET_FILE_DIR:${PROJECT_NAME}>
-    COMMENT "Copying adapter binaries to output directory"
+    COMMENT "Copying modbusadapter to output directory"
 )
 
 # Do platform specific post target stuff


### PR DESCRIPTION
dummymodbusadapter is a test-only binary and should not ship to end users. Remove it from the post-build copy step, the Linux staging directory, and the Windows deployment/installer bundle.

Tests that depend on it (tst_dummyadapter, tst_adapterprocess) use $<TARGET_FILE:dummymodbusadapter> which resolves to the adapters/ source directory, so they are unaffected.

https://claude.ai/code/session_0178BcJoyKufSNxEe4JNWXk4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment and packaging so release bundles no longer include an extra helper binary. Result: smaller downloads, reduced installer size, and lighter installations on Linux and Windows, with no changes to app behaviour or available features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModbusScope/ModbusScope/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->