### PR TITLE
fix: bump upload-artifact to v8 and add 3-day retention for branch builds

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -34,9 +34,10 @@ jobs:
       - name: Deploy
         run: bash scripts/deploy_linux.sh
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v8.0.1
         with:
           name: modbusscope-linux
+          retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}
           path: ModbusScope*.AppImage
 
   windows:
@@ -66,9 +67,10 @@ jobs:
         shell: cmd
         run: scripts\full_build_and_deploy_windows.bat '${{ steps.cache.outputs.cache-hit }}' ${{ github.workspace }}\Qt
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v8.0.1
         with:
           name: modbusscope-windows
+          retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}
           path: |
             ModbusScope.zip
             ModbusScope_setup.exe
@@ -86,9 +88,10 @@ jobs:
           sh create_doc.sh
           mv docs/manual/_build/latex/modbusscope.pdf modbusscope-user-manual.pdf
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v8.0.1
         with:
           name: modbusscope-user-manual
+          retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}
           path: modbusscope-user-manual.pdf
 
   package:
@@ -111,7 +114,8 @@ jobs:
           name: modbusscope-user-manual
           path: all-artifacts/docs
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v8.0.1
         with:
           name: modbusscope-all-platforms
+          retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}
           path: all-artifacts/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Deploy
         run: bash scripts/deploy_linux.sh
 
-      - uses: actions/upload-artifact@v8.0.1
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: modbusscope-linux
           retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}
@@ -67,7 +67,7 @@ jobs:
         shell: cmd
         run: scripts\full_build_and_deploy_windows.bat '${{ steps.cache.outputs.cache-hit }}' ${{ github.workspace }}\Qt
 
-      - uses: actions/upload-artifact@v8.0.1
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: modbusscope-windows
           retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}
@@ -88,7 +88,7 @@ jobs:
           sh create_doc.sh
           mv docs/manual/_build/latex/modbusscope.pdf modbusscope-user-manual.pdf
 
-      - uses: actions/upload-artifact@v8.0.1
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: modbusscope-user-manual
           retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}
@@ -114,7 +114,7 @@ jobs:
           name: modbusscope-user-manual
           path: all-artifacts/docs
 
-      - uses: actions/upload-artifact@v8.0.1
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: modbusscope-all-platforms
           retention-days: ${{ startsWith(github.ref, 'refs/tags/') && 90 || 3 }}


### PR DESCRIPTION
## Problem

This repo uploads ~800 MB of artifacts (AppImage + Windows installer + PDF + combined) on every branch push, with 90-day default retention. Because GitHub Actions storage is **org-wide**, this exhausts the shared quota and causes CI failures in ModbusScope/ModbusAdapter as well.

A secondary bug: `upload-artifact@v7.0.1` and `download-artifact@v8.0.1` use different storage backends and are incompatible, so the `package` job would also fail independently of the quota issue.

## Changes

- `actions/upload-artifact@v7.0.1` → `@v8.0.1` (matches the existing `download-artifact@v8.0.1` in the `package` job) — applies to all 4 upload steps
- Add `retention-days: 3` for branch builds, `retention-days: 90` for tag/release builds

## Note

After merging, old artifacts from past runs still count against quota until they expire or are deleted manually. To immediately free space: go to Actions → select old workflow runs → delete artifacts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfMYPAVDeYuG86L8FeKrZK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to refine artifact retention: artifacts from tagged releases are retained for 90 days, while non-tagged runs are retained for 3 days. This applies to platform builds, user manual and combined artifacts to improve storage management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->