### PR TITLE
Rename 'Register settings' menu item to 'Registers'

### DIFF
--- a/docs/manual/how-to/add-registers.md
+++ b/docs/manual/how-to/add-registers.md
@@ -8,9 +8,9 @@ You must have at least one connection and one device configured. See [Configure 
 
 ## Steps
 
-1. Click **Register Settings** in the toolbar.
+1. Click **Registers** in the toolbar.
 
-   ![Register settings dialog](<../_static/user_manual/add_register_dialog.png>)
+   ![Registers dialog](<../_static/user_manual/add_register_dialog.png>)
 
 2. Click **Add** to insert a new register row.
 3. In the **Expression** column, enter the register address using `${...}` syntax (e.g. `${40001}`). See [Reference: Register syntax](../reference/register-syntax.md) for all supported forms.

--- a/docs/manual/how-to/import-mbc-file.md
+++ b/docs/manual/how-to/import-mbc-file.md
@@ -11,7 +11,7 @@ This guide shows how to import register definitions from a ModbusControl (`.mbc`
 
 **Option B — menu:**
 
-1. Click **Register Settings** in the toolbar.
+1. Click **Registers** in the toolbar.
 2. Click **Import from .mbc file**.
 3. Select your `.mbc` file.
 
@@ -23,12 +23,12 @@ After opening the file with either option:
 
 2. Select the registers you want to add and click **Import**.
 
-**Result:** The selected registers are added to the register list with their names and addresses. You can edit them further in the Register Settings dialog.
+**Result:** The selected registers are added to the register list with their names and addresses. You can edit them further in the Registers dialog.
 
 ## Notes
 
 - ModbusControl is a separate proprietary application. This import feature only reads register definitions; it does not communicate with ModbusControl.
-- Imported registers use default types and colors. Adjust them in Register Settings if needed.
+- Imported registers use default types and colors. Adjust them in Registers if needed.
 
 ## See also
 

--- a/docs/manual/how-to/write-expressions.md
+++ b/docs/manual/how-to/write-expressions.md
@@ -4,7 +4,7 @@ This guide shows how to write an expression that calculates or combines register
 
 ## Steps
 
-1. Click **Register Settings** in the toolbar.
+1. Click **Registers** in the toolbar.
 2. In the row you want to edit, click the `...` button in the **Expression** column to open the **Compose expression** window.
 
    ![Compose expression dialog](<../_static/user_manual/expression_dialog.png>)

--- a/docs/manual/reference/csv-format.md
+++ b/docs/manual/reference/csv-format.md
@@ -19,7 +19,7 @@ Time (ms);Register 1;Register 2;Register 3
 | Column | Content | Type |
 | --- | --- | --- |
 | 1 | Timestamp | Integer (ms from session start) or absolute date-time when absolute timestamps are enabled |
-| 2..N | Register values | Numeric, one column per register in the order they appear in Register Settings |
+| 2..N | Register values | Numeric, one column per register in the order they appear in Registers |
 
 ## Separators (export)
 

--- a/docs/manual/tutorials/first-logging-session.md
+++ b/docs/manual/tutorials/first-logging-session.md
@@ -33,7 +33,7 @@ If your device uses different values, substitute them at each step.
 
 ## Step 3 — Add registers
 
-1. Click **Register Settings** in the toolbar.
+1. Click **Registers** in the toolbar.
 2. Click **Add** to add a new row.
 3. In the **Expression** column, type `${40001}`. Set **Name** to `Register 1`.
 4. Add a second row: expression `${40002}`, name `Register 2`.

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -60,7 +60,7 @@ MainWindow::MainWindow(QStringList cmdArguments,
     QApplication::setStyle(QStyleFactory::create("Fusion"));
 
     _pOverlayLabel =
-      new OverlayLabel(tr("No registers configured — click Register Settings to add one"), _pUi->customPlot);
+      new OverlayLabel(tr("No registers configured — click Registers to add one"), _pUi->customPlot);
 
     _pDiagnosticDialog = new DiagnosticDialog(_pDiagnosticModel, this);
 

--- a/src/dialogs/mainwindow.ui
+++ b/src/dialogs/mainwindow.ui
@@ -415,7 +415,7 @@
      <normaloff>:/menu_icon/icons/list.svg</normaloff>:/menu_icon/icons/list.svg</iconset>
    </property>
    <property name="text">
-    <string>&amp;Register settings...</string>
+    <string>&amp;Registers</string>
    </property>
    <property name="iconText">
     <string>Registers</string>

--- a/src/dialogs/registerdialog.ui
+++ b/src/dialogs/registerdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Register settings</string>
+   <string>Registers</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Renamed menu and dialog labels to "Registers" for clearer, consistent UI wording.
  * Updated empty-state overlay to instruct users to "click Registers" when no registers exist.

* **Documentation**
  * Updated multiple how‑to guides, tutorials and reference docs to use "Registers" and adjusted screenshots and step text accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->