### PR TITLE
Always build Release configuration in CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,7 +4,7 @@ name: Build
 on: push
 
 env:
-  BUILD_TYPE: ${{ startsWith(github.ref, 'refs/tags/') && 'Release' || 'Debug' }}
+  BUILD_TYPE: Release
 
 jobs:
   linux:


### PR DESCRIPTION
Previously the build type was Debug for regular pushes and Release only
for tagged commits. This unconditionally uses Release to reduce artifact
size on every run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to standardise build configuration. The build process now consistently uses Release mode for all automated builds, replacing the previous dynamic selection logic that switched between Release and Debug modes based on deployment context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->