### PR TITLE
Use latest docker with clang-tidy and clazy installed

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: docker://jgeudens/qt-linux:6.8.3_build_1
+      image: docker://jgeudens/qt-linux:6.8.3_build_2
     steps:
       - uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -47,7 +47,7 @@ jobs:
         id: cache
         with:
           path: ${{ github.workspace }}\Qt
-          key: ${{ runner.os }}-qt-build-${{ hashFiles('scripts\setup_windows.bat') }}
+          key: ${{ runner.os }}-qt-build-${{ hashFiles('scripts/setup_windows.bat') }}
 
       - name: Setup, build and deploy
         shell: cmd

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Install Qt installer
         run: pip3 install aqtinstall==3.3.0
 
+      - name: Qt Build Cache
+        uses: actions/cache@v5.0.5
+        id: cache
+        with:
+          path: ${{ github.workspace }}\Qt
+          key: ${{ runner.os }}-qt-build-${{ hashFiles('scripts\setup_windows.bat') }}
+
       - name: Setup, build and deploy
         shell: cmd
         run: scripts\full_build_and_deploy_windows.bat '${{ steps.cache.outputs.cache-hit }}' ${{ github.workspace }}\Qt

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    container: docker://jgeudens/qt-linux:6.8.3_build_1
+    container: docker://jgeudens/qt-linux:6.8.3_build_2
     steps:
     - name: Checkout
       uses: actions/checkout@v6.0.2
@@ -45,34 +45,24 @@ jobs:
 
   clazy:
     runs-on: ubuntu-latest
-    container: docker://jgeudens/qt-linux:6.8.3_build_1
+    container: docker://jgeudens/qt-linux:6.8.3_build_2
     steps:
     - uses: actions/checkout@v6.0.2
 
     - name: Configure safe directory for git
       run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-
-    - name: Install clazy
-      run: |
-        apt-get update
-        apt-get install -y clazy
 
     - name: Run clazy
       run: bash scripts/run_clazy.sh
 
   clang-tidy:
     runs-on: ubuntu-latest
-    container: docker://jgeudens/qt-linux:6.8.3_build_1
+    container: docker://jgeudens/qt-linux:6.8.3_build_2
     steps:
     - uses: actions/checkout@v6.0.2
 
     - name: Configure safe directory for git
       run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-
-    - name: Install clang-tidy
-      run: |
-        apt-get update
-        apt-get install -y clang-tidy
 
     - name: Run clang-tidy
       run: bash scripts/run_clang_tidy.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Linux/container build environment to a newer image for build and code-quality jobs.
  * Simplified code-quality workflow steps to rely on the updated container setup.
  * Added a Windows Qt build cache to speed Windows builds and expose cache-hit information to the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->