### PR TITLE
Build Release only on tags, Debug otherwise

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,7 +4,7 @@ name: Build
 on: push
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: ${{ startsWith(github.ref, 'refs/tags/') && 'Release' || 'Debug' }}
 
 jobs:
   linux:


### PR DESCRIPTION
## Summary
- CI previously always built with `BUILD_TYPE=Release` on every push
- `BUILD_TYPE` in `.github/workflows/ccpp.yml` now resolves to `Release` only for tag pushes (`refs/tags/*`), and `Debug` for all other pushes

## Test plan
- [ ] Push/PR triggers CI and confirms a non-tag build uses Debug
- [ ] Tag push triggers CI and confirms it uses Release


---
_Generated by [Claude Code](https://claude.ai/code/session_015MSwN7jqRR1rLBvY6ojBRJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build automation so tagged releases use a release build, while non-tagged runs use a debug build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->