### PR TITLE
Fix CodeRabbit review findings on PR #487

### DIFF
--- a/adapters/CHANGELOG.md
+++ b/adapters/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Remove the application name directory from the license file path (now `~/.config/ModbusScope/licenses/<adapter>.lic`)
 - Change supported devices to 2 in free version
 - Update capabilities
-  - Remove unused `supportsHotReload`and `requiresRestartOn`
+  - Remove unused `supportsHotReload` and `requiresRestartOn`
   - Add `mbcCompatible`
 
 ## v0.0.2 - (07/05/2026)

--- a/adapters/THIRD_PARTY_LICENSES.md
+++ b/adapters/THIRD_PARTY_LICENSES.md
@@ -9,7 +9,7 @@ license text must accompany any distributed copy of these binaries.
 - License: ISC License
 - Copyright: Copyright (c) 2013-2026 Frank Denis <j at pureftpd dot org>
 
-```
+```text
 ISC License
 
 Copyright (c) 2013-2026

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -20,7 +20,7 @@ QString licenseLogText(const AdapterLicenseInfo& info)
     }
     if (info.state == "valid")
     {
-        QString text = QString("license valid: %1 <%2>, ID %3").arg(info.customer, info.email, info.licenseId);
+        QString text = QString("license valid for %1").arg(info.customer);
         if (!info.expires.isEmpty())
         {
             text += QString(", expires %1").arg(info.expires);


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review findings from #487:

- Add missing space in `adapters/CHANGELOG.md` changelog entry
- Label the license text block in `adapters/THIRD_PARTY_LICENSES.md` as `text` to satisfy markdownlint (MD040)
- Stop logging customer email and license ID in `SettingsModel`'s `licenseLogText()` — these diagnostic logs can end up in shared bug reports; full license details remain available in the About dialog UI

## Not addressed

CodeRabbit also flagged that `adapters/describe.json`'s `capabilities.maxDevices` (99) doesn't reflect the free-tier 2-device cap. That file is a static captured reference of the vendored adapter binary's actual `adapter.describe` output (not consumed by any code or test in this repo), so it can't be edited to add a new field without also changing the adapter binary itself, which is out of scope here. The free-tier limit is already documented in `adapters/modbus-adapter-spec.md`.

## Test plan

- [ ] CI build and test suite pass


---
_Generated by [Claude Code](https://claude.ai/code/session_014JKSoBuUAtUJ7vk5gKAtpC)_