### PR TITLE
Add adapter selection to register and expression dialogs

### DIFF
--- a/src/ProtocolAdapter/adapterhub.cpp
+++ b/src/ProtocolAdapter/adapterhub.cpp
@@ -173,10 +173,6 @@ void AdapterHub::onManagerSessionStarted(const QString& id)
 void AdapterHub::onManagerSessionError(const QString& id, const QString& message)
 {
     _pendingStartAdapters.remove(id);
-    if (_pendingStartAdapters.isEmpty())
-    {
-        emit sessionStarted();
-    }
     emit sessionError(message);
 }
 

--- a/src/ProtocolAdapter/adapterhub.cpp
+++ b/src/ProtocolAdapter/adapterhub.cpp
@@ -110,6 +110,14 @@ AdapterManager* AdapterHub::adapterManager(const QString& id) const
     return _adapterManagers.value(id, nullptr);
 }
 
+/*! \brief Return the list of discovered adapter IDs.
+ * \return QStringList of adapter ID strings, sorted alphabetically.
+ */
+QStringList AdapterHub::adapterIds() const
+{
+    return _adapterManagers.keys();
+}
+
 /*! \brief Returns true when all adapter managers are in AWAITING_CONFIG state. */
 bool AdapterHub::isAdapterReady() const
 {

--- a/src/ProtocolAdapter/adapterhub.h
+++ b/src/ProtocolAdapter/adapterhub.h
@@ -37,6 +37,7 @@ public:
     virtual void requestReadData();
 
     virtual AdapterManager* adapterManager(const QString& id) const;
+    virtual QStringList adapterIds() const;
     virtual bool isAdapterReady() const;
     virtual bool isAdapterIdle() const;
 

--- a/src/ProtocolAdapter/adapterhub.h
+++ b/src/ProtocolAdapter/adapterhub.h
@@ -28,6 +28,9 @@ class SettingsModel;
 class AdapterHub : public QObject
 {
     Q_OBJECT
+
+    friend class TestAdapterHub;
+
 public:
     explicit AdapterHub(SettingsModel* pSettingsModel, QObject* parent = nullptr);
 

--- a/src/communication/adapterpoll.cpp
+++ b/src/communication/adapterpoll.cpp
@@ -213,13 +213,7 @@ void AdapterPoll::buildAdapterGroups(const QList<DataPoint>& registerList)
     for (int i = 0; i < registerList.size(); i++)
     {
         const DataPoint& dp = registerList[i];
-        Device* dev = _pSettingsModel->deviceSettings(dp.deviceId());
-        if (dev == nullptr)
-        {
-            qCWarning(scopeComm) << "AdapterPoll: no device settings for deviceId" << dp.deviceId() << "at index" << i
-                                 << "— defaulting to modbus adapter";
-        }
-        const QString adapterId = (dev != nullptr) ? dev->adapterId() : cModbusAdapterId;
+        const QString adapterId = _pSettingsModel->adapterIdForDevice(dp.deviceId());
         _adapterGroups[adapterId].expressions.append(dp.address());
         _adapterGroups[adapterId].originalIndices.append(i);
     }

--- a/src/dialogs/adapterdevicesettings.cpp
+++ b/src/dialogs/adapterdevicesettings.cpp
@@ -77,6 +77,7 @@ AdapterDeviceSettings::AdapterDeviceSettings(SettingsModel* pSettingsModel, QWid
                 }
                 seenDeviceIds.insert(devId);
                 pSettingsModel->addDevice(devId);
+                pSettingsModel->deviceSettings(devId)->setAdapterId(adapterId);
             }
             auto* tab = new DeviceConfigTab(pSettingsModel, adapterId, deviceObj, _pDeviceTabs);
             connectTabNameTracking(tab);

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -121,9 +121,27 @@ void AddRegisterWidget::applyAdapter(const QString& adapterId)
     const QJsonObject dataPointSchema = _pSettingsModel->adapterData(adapterId)->dataPointSchema();
     _addressSchema = buildSchema(adapterId);
     _dataPointDefaults = dataPointSchema["defaults"].toObject();
-    _pAddressForm->setSchema(_addressSchema, _dataPointDefaults);
+    rebuildAddressForm();
 
-    _pUi->btnAdd->setEnabled(!_pSettingsModel->deviceListForAdapter(adapterId).isEmpty());
+    _pUi->btnAdd->setEnabled(isAdapterUsable(adapterId));
+}
+
+/*!
+ * \brief Rebuilds the address form widgets from the currently cached schema and defaults.
+ */
+void AddRegisterWidget::rebuildAddressForm()
+{
+    _pAddressForm->setSchema(_addressSchema, _dataPointDefaults);
+}
+
+/*!
+ * \brief Returns whether the given adapter has a manager and at least one configured device.
+ * \param adapterId Identifier of the adapter to check.
+ */
+bool AddRegisterWidget::isAdapterUsable(const QString& adapterId) const
+{
+    return (_pAdapterHub->adapterManager(adapterId) != nullptr) &&
+           !_pSettingsModel->deviceListForAdapter(adapterId).isEmpty();
 }
 
 /*!
@@ -171,9 +189,7 @@ void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
 {
     /* Recompute instead of unconditionally enabling: the user may have switched
      * to an adapter without devices while the request was in flight */
-    const bool selectedAdapterUsable =
-      (_pAdapterManager != nullptr) && !_pSettingsModel->deviceListForAdapter(selectedAdapterId()).isEmpty();
-    _pUi->btnAdd->setEnabled(selectedAdapterUsable);
+    _pUi->btnAdd->setEnabled(isAdapterUsable(selectedAdapterId()));
 
     if (expression.isEmpty())
     {
@@ -184,13 +200,13 @@ void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
     emit graphDataConfigured(_pendingGraphData);
 
     resetFields();
+    rebuildAddressForm();
 }
 
 void AddRegisterWidget::resetFields()
 {
     _pUi->lineName->setText("Name of curve");
     _pUi->radioPrimary->setChecked(true);
-    _pAddressForm->setSchema(_addressSchema, _dataPointDefaults);
 }
 
 /*!

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -1,6 +1,7 @@
 #include "addregisterwidget.h"
 #include "ui_addregisterwidget.h"
 
+#include "ProtocolAdapter/adapterhub.h"
 #include "ProtocolAdapter/adaptermanager.h"
 #include "customwidgets/schemaformwidget.h"
 #include "models/adapterdata.h"
@@ -11,21 +12,21 @@
 #include <QVBoxLayout>
 
 /*!
- * \brief Constructs the widget and populates it from the adapter's register schema.
+ * \brief Constructs the widget and populates it from the selected adapter's register schema.
+ *
+ * The adapter selector is filled with all discovered adapters and hidden when
+ * only a single adapter is available.
  * \param pSettingsModel Pointer to the application settings model.
- * \param adapterId      Identifier of the adapter whose register schema to use.
- * \param pAdapterManager Pointer to the adapter manager used to build expression strings.
+ * \param pAdapterHub    Pointer to the adapter hub used to look up adapter managers.
  * \param parent         Optional parent widget.
  */
-AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel,
-                                     const QString& adapterId,
-                                     AdapterManager* pAdapterManager,
-                                     QWidget* parent)
+AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel, AdapterHub* pAdapterHub, QWidget* parent)
     : QWidget(parent),
       _pUi(new Ui::AddRegisterWidget),
       _pAddressForm(new SchemaFormWidget(this)),
       _pSettingsModel(pSettingsModel),
-      _pAdapterManager(pAdapterManager)
+      _pAdapterHub(pAdapterHub),
+      _pAdapterManager(nullptr)
 {
     _pUi->setupUi(this);
 
@@ -35,18 +36,24 @@ AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel,
     /* Disable question mark button */
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-    const QJsonObject dataPointSchema = pSettingsModel->adapterData(adapterId)->dataPointSchema();
-    _addressSchema = buildSchema(adapterId);
-    _dataPointDefaults = dataPointSchema["defaults"].toObject();
-
     auto* addressLayout = new QVBoxLayout(_pUi->addressContainer);
     addressLayout->setContentsMargins(0, 0, 0, 0);
     addressLayout->addWidget(_pAddressForm);
 
-    if (_pSettingsModel->deviceListForAdapter(adapterId).isEmpty())
+    const QStringList adapterIds = _pAdapterHub->adapterIds();
+    for (const QString& adapterId : adapterIds)
     {
-        _pUi->btnAdd->setEnabled(false);
+        QString label = _pSettingsModel->adapterData(adapterId)->name();
+        if (label.isEmpty())
+        {
+            label = adapterId;
+        }
+        _pUi->cmbAdapter->addItem(label, adapterId);
     }
+    _pUi->cmbAdapter->setVisible(adapterIds.size() > 1);
+
+    /* Connect after populating to avoid spurious slot calls during addItem */
+    connect(_pUi->cmbAdapter, &QComboBox::currentIndexChanged, this, &AddRegisterWidget::onAdapterSelectionChanged);
 
     connect(_pUi->btnAdd, &QPushButton::clicked, this, &AddRegisterWidget::handleResultAccept);
 
@@ -54,6 +61,7 @@ AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel,
     _axisGroup.addButton(_pUi->radioPrimary);
     _axisGroup.addButton(_pUi->radioSecondary);
 
+    applyAdapter(selectedAdapterId());
     resetFields();
 }
 
@@ -94,8 +102,58 @@ QJsonObject AddRegisterWidget::buildSchema(const QString& adapterId) const
     return schema;
 }
 
+/*!
+ * \brief Switch the widget to the given adapter's register schema.
+ *
+ * Rebuilds the address form from the adapter's data point schema and updates
+ * the add button state based on manager and device availability.
+ * \param adapterId Identifier of the adapter to use.
+ */
+void AddRegisterWidget::applyAdapter(const QString& adapterId)
+{
+    _pAdapterManager = _pAdapterHub->adapterManager(adapterId);
+    if (_pAdapterManager == nullptr)
+    {
+        _pUi->btnAdd->setEnabled(false);
+        return;
+    }
+
+    const QJsonObject dataPointSchema = _pSettingsModel->adapterData(adapterId)->dataPointSchema();
+    _addressSchema = buildSchema(adapterId);
+    _dataPointDefaults = dataPointSchema["defaults"].toObject();
+    _pAddressForm->setSchema(_addressSchema, _dataPointDefaults);
+
+    _pUi->btnAdd->setEnabled(!_pSettingsModel->deviceListForAdapter(adapterId).isEmpty());
+}
+
+/*!
+ * \brief Returns the adapter ID of the adapter currently selected in the adapter combo box.
+ */
+QString AddRegisterWidget::selectedAdapterId() const
+{
+    return _pUi->cmbAdapter->currentData().toString();
+}
+
+/*!
+ * \brief Rebuilds the address form when another adapter is selected.
+ *
+ * The curve name and axis selection are kept so switching adapters only
+ * replaces the address fields.
+ * \param index Index of the newly selected combo box entry (unused).
+ */
+void AddRegisterWidget::onAdapterSelectionChanged(int index)
+{
+    Q_UNUSED(index);
+    applyAdapter(selectedAdapterId());
+}
+
 void AddRegisterWidget::handleResultAccept()
 {
+    if (_pAdapterManager == nullptr)
+    {
+        return;
+    }
+
     collectPendingGraphData();
 
     QJsonObject allValues = _pAddressForm->values();
@@ -111,7 +169,11 @@ void AddRegisterWidget::handleResultAccept()
 
 void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
 {
-    _pUi->btnAdd->setEnabled(true);
+    /* Recompute instead of unconditionally enabling: the user may have switched
+     * to an adapter without devices while the request was in flight */
+    const bool selectedAdapterUsable =
+      (_pAdapterManager != nullptr) && !_pSettingsModel->deviceListForAdapter(selectedAdapterId()).isEmpty();
+    _pUi->btnAdd->setEnabled(selectedAdapterUsable);
 
     if (expression.isEmpty())
     {

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -39,6 +39,8 @@ private:
     void resetFields();
     void collectPendingGraphData();
     void applyAdapter(const QString& adapterId);
+    void rebuildAddressForm();
+    bool isAdapterUsable(const QString& adapterId) const;
     QString selectedAdapterId() const;
     QJsonObject buildSchema(const QString& adapterId) const;
 

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -8,6 +8,7 @@
 #include <QJsonObject>
 #include <QWidget>
 
+class AdapterHub;
 class AdapterManager;
 class SchemaFormWidget;
 class SettingsModel;
@@ -23,10 +24,7 @@ class AddRegisterWidget : public QWidget
     friend class TestAddRegisterWidget;
 
 public:
-    explicit AddRegisterWidget(SettingsModel* pSettingsModel,
-                               const QString& adapterId,
-                               AdapterManager* pAdapterManager,
-                               QWidget* parent = nullptr);
+    explicit AddRegisterWidget(SettingsModel* pSettingsModel, AdapterHub* pAdapterHub, QWidget* parent = nullptr);
     ~AddRegisterWidget();
 
 signals:
@@ -35,10 +33,13 @@ signals:
 private slots:
     void handleResultAccept();
     void onBuildExpressionResult(const QString& expression);
+    void onAdapterSelectionChanged(int index);
 
 private:
     void resetFields();
     void collectPendingGraphData();
+    void applyAdapter(const QString& adapterId);
+    QString selectedAdapterId() const;
     QJsonObject buildSchema(const QString& adapterId) const;
 
     Ui::AddRegisterWidget* _pUi;
@@ -47,6 +48,7 @@ private:
     QJsonObject _dataPointDefaults;
 
     SettingsModel* _pSettingsModel;
+    AdapterHub* _pAdapterHub;
     AdapterManager* _pAdapterManager;
 
     QButtonGroup _axisGroup;

--- a/src/dialogs/addregisterwidget.ui
+++ b/src/dialogs/addregisterwidget.ui
@@ -30,16 +30,19 @@
        <number>6</number>
       </property>
       <item row="0" column="0" colspan="2">
+       <widget class="QComboBox" name="cmbAdapter"/>
+      </item>
+      <item row="1" column="0" colspan="2">
        <widget class="QLineEdit" name="lineName">
         <property name="text">
          <string>Name of curve</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="2" column="0" colspan="2">
        <widget class="QWidget" name="addressContainer" native="true"/>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QRadioButton" name="radioPrimary">
         <property name="text">
          <string>Y1 axis</string>
@@ -49,7 +52,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QRadioButton" name="radioSecondary">
         <property name="text">
          <string>Y2 axis</string>

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -1,20 +1,25 @@
 #include "expressionsdialog.h"
 #include "ui_expressionsdialog.h"
 
+#include "ProtocolAdapter/adapterhub.h"
 #include "ProtocolAdapter/adaptermanager.h"
 #include "dialogs/expressionhighlighting.h"
+#include "models/adapterdata.h"
 #include "models/graphdatamodel.h"
+#include "models/settingsmodel.h"
 
 using State = ResultState::State;
 
 ExpressionsDialog::ExpressionsDialog(GraphDataModel* pGraphDataModel,
                                      GraphIdx idx,
-                                     AdapterManager* pAdapterManager,
+                                     AdapterHub* pAdapterHub,
+                                     SettingsModel* pSettingsModel,
                                      QWidget* parent)
     : QDialog(parent),
       _pUi(new Ui::ExpressionsDialog),
       _pGraphDataModel(pGraphDataModel),
-      _pAdapterManager(pAdapterManager),
+      _pAdapterHub(pAdapterHub),
+      _pSettingsModel(pSettingsModel),
       _bUpdating(false)
 {
     _pUi->setupUi(this);
@@ -25,12 +30,7 @@ ExpressionsDialog::ExpressionsDialog(GraphDataModel* pGraphDataModel,
 
     connect(&_expressionChecker, &ExpressionChecker::resultsReady, this, &ExpressionsDialog::handleResultReady);
 
-    if (_pAdapterManager != nullptr)
-    {
-        connect(_pAdapterManager, &AdapterManager::expressionHelpResult, this,
-                &ExpressionsDialog::handleExpressionHelpResult);
-        _pAdapterManager->requestExpressionHelp();
-    }
+    populateHelpAdapters();
 
     _pUi->tblExpressionInput->setRowCount(0);
     _pUi->tblExpressionInput->setColumnCount(2);
@@ -95,10 +95,11 @@ void ExpressionsDialog::handleExpressionChange()
         _bUpdating = false;
 
         _pendingDescribeAddresses = addresses;
+        _pendingDescribeDeviceIds = _expressionChecker.deviceIds();
         _nextDescribeRow = 0;
-        if (_pAdapterManager != nullptr)
+        if (_pDescribeManager != nullptr)
         {
-            QObject::disconnect(_pAdapterManager, &AdapterManager::describeDataPointResult, this,
+            QObject::disconnect(_pDescribeManager, &AdapterManager::describeDataPointResult, this,
                                 &ExpressionsDialog::handleDescribeDataPointResult);
         }
         startNextDescribe();
@@ -153,14 +154,124 @@ void ExpressionsDialog::handleExpressionHelpResult(const QString& helpText)
     _pUi->lblInfo->setText(helpText);
 }
 
+/*!
+ * \brief Fill the help adapter selector and request help text for the initial selection.
+ *
+ * The selector is hidden when fewer than two adapters are available.
+ */
+void ExpressionsDialog::populateHelpAdapters()
+{
+    if (_pAdapterHub == nullptr)
+    {
+        _pUi->widgetHelpAdapter->setVisible(false);
+        return;
+    }
+
+    const QStringList adapterIds = _pAdapterHub->adapterIds();
+    for (const QString& adapterId : adapterIds)
+    {
+        QString label;
+        if (_pSettingsModel != nullptr)
+        {
+            label = _pSettingsModel->adapterData(adapterId)->name();
+        }
+        if (label.isEmpty())
+        {
+            label = adapterId;
+        }
+        _pUi->cmbHelpAdapter->addItem(label, adapterId);
+    }
+    _pUi->widgetHelpAdapter->setVisible(adapterIds.size() > 1);
+
+    /* Connect after populating to avoid spurious slot calls during addItem */
+    connect(_pUi->cmbHelpAdapter, &QComboBox::currentIndexChanged, this, &ExpressionsDialog::onHelpAdapterChanged);
+
+    if (!adapterIds.isEmpty())
+    {
+        requestHelpForAdapter(_pUi->cmbHelpAdapter->currentData().toString());
+    }
+}
+
+/*!
+ * \brief Request expression help text from the given adapter.
+ *
+ * Any pending help connection to a previously selected adapter is dropped so a
+ * late response cannot overwrite the newly selected adapter's help text.
+ * \param adapterId Identifier of the adapter to request help from.
+ */
+void ExpressionsDialog::requestHelpForAdapter(const QString& adapterId)
+{
+    if (_pHelpManager != nullptr)
+    {
+        QObject::disconnect(_pHelpManager, &AdapterManager::expressionHelpResult, this,
+                            &ExpressionsDialog::handleExpressionHelpResult);
+    }
+
+    _pUi->lblInfo->clear();
+
+    _pHelpManager = _pAdapterHub->adapterManager(adapterId);
+    if (_pHelpManager == nullptr)
+    {
+        return;
+    }
+
+    connect(_pHelpManager, &AdapterManager::expressionHelpResult, this,
+            &ExpressionsDialog::handleExpressionHelpResult, Qt::SingleShotConnection);
+    _pHelpManager->requestExpressionHelp();
+}
+
+/*!
+ * \brief Show the expression help of the newly selected adapter.
+ * \param index Index of the newly selected combo box entry (unused).
+ */
+void ExpressionsDialog::onHelpAdapterChanged(int index)
+{
+    Q_UNUSED(index);
+    requestHelpForAdapter(_pUi->cmbHelpAdapter->currentData().toString());
+}
+
+/*!
+ * \brief Resolve the adapter manager responsible for the data point at the given row.
+ *
+ * The row's device ID is mapped to its owning adapter via the settings model.
+ * \param row Row index into the pending describe lists.
+ * \return Pointer to the manager, or nullptr when it is unknown or not running.
+ */
+AdapterManager* ExpressionsDialog::managerForDescribeRow(qint32 row) const
+{
+    if (_pAdapterHub == nullptr || _pSettingsModel == nullptr || row >= _pendingDescribeDeviceIds.size())
+    {
+        return nullptr;
+    }
+
+    const QString adapterId = _pSettingsModel->adapterIdForDevice(_pendingDescribeDeviceIds[row]);
+    AdapterManager* pManager = _pAdapterHub->adapterManager(adapterId);
+    if (pManager == nullptr || pManager->isAdapterIdle())
+    {
+        return nullptr;
+    }
+
+    return pManager;
+}
+
 void ExpressionsDialog::startNextDescribe()
 {
-    if (_pAdapterManager != nullptr && !_pAdapterManager->isAdapterIdle() &&
-        _nextDescribeRow < _pendingDescribeAddresses.size())
+    _pDescribeManager = nullptr;
+    while (_nextDescribeRow < _pendingDescribeAddresses.size() && _pDescribeManager == nullptr)
     {
-        connect(_pAdapterManager, &AdapterManager::describeDataPointResult, this,
-                &ExpressionsDialog::handleDescribeDataPointResult, Qt::SingleShotConnection);
-        _pAdapterManager->describeDataPoint(_pendingDescribeAddresses[_nextDescribeRow]);
+        AdapterManager* pManager = managerForDescribeRow(_nextDescribeRow);
+        if (pManager != nullptr)
+        {
+            _pDescribeManager = pManager;
+            connect(pManager, &AdapterManager::describeDataPointResult, this,
+                    &ExpressionsDialog::handleDescribeDataPointResult, Qt::SingleShotConnection);
+            pManager->describeDataPoint(_pendingDescribeAddresses[_nextDescribeRow]);
+        }
+        else
+        {
+            /* Adapter unavailable for this row: keep the parser description and try the next row */
+            _nextDescribeRow++;
+        }
     }
 }
 

--- a/src/dialogs/expressionsdialog.h
+++ b/src/dialogs/expressionsdialog.h
@@ -9,8 +9,10 @@
 #include <QStringList>
 
 /* Forward declarations */
+class AdapterHub;
 class AdapterManager;
 class ExpressionHighlighting;
+class SettingsModel;
 
 namespace Ui {
 class ExpressionsDialog;
@@ -23,7 +25,8 @@ class ExpressionsDialog : public QDialog
 public:
     explicit ExpressionsDialog(GraphDataModel* pGraphDataModel,
                                GraphIdx idx,
-                               AdapterManager* pAdapterManager,
+                               AdapterHub* pAdapterHub,
+                               SettingsModel* pSettingsModel,
                                QWidget* parent = nullptr);
     ~ExpressionsDialog();
 
@@ -35,16 +38,23 @@ private slots:
     void handleResultReady(bool valid);
     void handleExpressionHelpResult(const QString& helpText);
     void handleDescribeDataPointResult(const QJsonObject& result);
+    void onHelpAdapterChanged(int index);
 
 private:
     void startNextDescribe();
+    void populateHelpAdapters();
+    void requestHelpForAdapter(const QString& adapterId);
+    AdapterManager* managerForDescribeRow(qint32 row) const;
 
     Ui::ExpressionsDialog* _pUi;
 
     GraphIdx _graphIdx;
 
     GraphDataModel* _pGraphDataModel;
-    AdapterManager* _pAdapterManager;
+    AdapterHub* _pAdapterHub;
+    SettingsModel* _pSettingsModel;
+    AdapterManager* _pDescribeManager = nullptr;
+    AdapterManager* _pHelpManager = nullptr;
 
     ExpressionChecker _expressionChecker;
     ExpressionHighlighting* _pHighlighter;
@@ -52,6 +62,7 @@ private:
     bool _bUpdating;
 
     QStringList _pendingDescribeAddresses;
+    QList<deviceId_t> _pendingDescribeDeviceIds;
     qint32 _nextDescribeRow = 0;
 };
 

--- a/src/dialogs/expressionsdialog.ui
+++ b/src/dialogs/expressionsdialog.ui
@@ -202,6 +202,47 @@
        <number>0</number>
       </property>
       <item>
+       <widget class="QWidget" name="widgetHelpAdapter" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="lblHelpAdapter">
+           <property name="text">
+            <string>Adapter</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cmbHelpAdapter"/>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="lblInfo">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -424,13 +424,13 @@ void MainWindow::showRegisterDialog()
         _pGuiModel->setGuiState(GuiState::INIT);
     }
 
-    AdapterManager* pAdapterManager = _pScopeController->adapterHub()->adapterManager(cModbusAdapterId);
-    if (pAdapterManager == nullptr)
+    AdapterHub* pAdapterHub = _pAdapterPoll->adapterHub();
+    if (pAdapterHub->adapterIds().isEmpty())
     {
-        qCWarning(scopeComm) << "MainWindow: no modbus adapter available — cannot open register dialog";
+        qCWarning(scopeComm) << "MainWindow: no adapters available — cannot open register dialog";
         return;
     }
-    RegisterDialog registerDialog(_pGraphDataModel, _pSettingsModel, pAdapterManager, this);
+    RegisterDialog registerDialog(_pGraphDataModel, _pSettingsModel, pAdapterHub, this);
     registerDialog.exec();
 }
 

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -424,7 +424,7 @@ void MainWindow::showRegisterDialog()
         _pGuiModel->setGuiState(GuiState::INIT);
     }
 
-    AdapterHub* pAdapterHub = _pAdapterPoll->adapterHub();
+    AdapterHub* pAdapterHub = _pScopeController->adapterHub();
     if (pAdapterHub->adapterIds().isEmpty())
     {
         qCWarning(scopeComm) << "MainWindow: no adapters available — cannot open register dialog";

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -1,6 +1,7 @@
 
 #include "registerdialog.h"
 
+#include "ProtocolAdapter/adapterhub.h"
 #include "ProtocolAdapter/adaptermanager.h"
 #include "customwidgets/actionbuttondelegate.h"
 #include "dialogs/addregisterwidget.h"
@@ -15,7 +16,7 @@
 
 RegisterDialog::RegisterDialog(GraphDataModel* pGraphDataModel,
                                SettingsModel* pSettingsModel,
-                               AdapterManager* pAdapterManager,
+                               AdapterHub* pAdapterHub,
                                QWidget* parent)
     : QDialog(parent), _pUi(new Ui::RegisterDialog)
 {
@@ -26,9 +27,14 @@ RegisterDialog::RegisterDialog(GraphDataModel* pGraphDataModel,
 
     _pGraphDataModel = pGraphDataModel;
     _pSettingsModel = pSettingsModel;
-    _pAdapterManager = pAdapterManager;
+    _pAdapterHub = pAdapterHub;
+    _pDefaultExpressionManager = defaultExpressionManager();
 
-    connect(_pAdapterManager, &AdapterManager::sessionStarted, this, &RegisterDialog::requestDefaultExpression);
+    if (_pDefaultExpressionManager != nullptr)
+    {
+        connect(_pDefaultExpressionManager, &AdapterManager::sessionStarted, this,
+                &RegisterDialog::requestDefaultExpression);
+    }
 
     // Setup registerView
     _pUi->registerView->setModel(_pGraphDataModel);
@@ -75,10 +81,9 @@ RegisterDialog::RegisterDialog(GraphDataModel* pGraphDataModel,
     connect(_pUi->btnRemove, &QPushButton::released, this, &RegisterDialog::removeRegisterRow);
     connect(_pGraphDataModel, &GraphDataModel::rowsInserted, this, &RegisterDialog::onRegisterInserted);
 
-    const QString adapterId = _pAdapterManager->adapterId();
-    if (!adapterId.isEmpty())
+    if (!_pAdapterHub->adapterIds().isEmpty())
     {
-        auto registerPopupMenu = new AddRegisterWidget(_pSettingsModel, adapterId, _pAdapterManager, this);
+        auto registerPopupMenu = new AddRegisterWidget(_pSettingsModel, _pAdapterHub, this);
         connect(registerPopupMenu, &AddRegisterWidget::graphDataConfigured, this, &RegisterDialog::addRegister);
 
         _registerPopupAction = std::make_unique<QWidgetAction>(this);
@@ -151,10 +156,32 @@ void RegisterDialog::handleExpressionEdit(const QModelIndex& index)
     {
         _pUi->registerView->closePersistentEditor(index);
 
-        ExpressionsDialog exprDialog(_pGraphDataModel, GraphIdx(index.row()), _pAdapterManager, this);
+        ExpressionsDialog exprDialog(_pGraphDataModel, GraphIdx(index.row()), _pAdapterHub, _pSettingsModel, this);
 
         exprDialog.exec();
     }
+}
+
+/*!
+ * \brief Determine which adapter manager drives the default new-register expression.
+ *
+ * The modbus adapter is preferred to keep the existing single-adapter behavior;
+ * when it is not available the first discovered adapter is used.
+ * \return Pointer to the manager, or nullptr when no adapters are available.
+ */
+AdapterManager* RegisterDialog::defaultExpressionManager() const
+{
+    AdapterManager* pManager = _pAdapterHub->adapterManager(cModbusAdapterId);
+    if (pManager == nullptr)
+    {
+        const QStringList adapterIds = _pAdapterHub->adapterIds();
+        if (!adapterIds.isEmpty())
+        {
+            pManager = _pAdapterHub->adapterManager(adapterIds.first());
+        }
+    }
+
+    return pManager;
 }
 
 int RegisterDialog::selectedRowAfterDelete(int deletedStartIndex, int rowCnt)
@@ -190,22 +217,29 @@ bool RegisterDialog::sortRegistersLastFirst(const QModelIndex& s1, const QModelI
  */
 void RegisterDialog::requestDefaultExpression()
 {
-    const QJsonObject defaults =
-      _pSettingsModel->adapterData(_pAdapterManager->adapterId())->dataPointSchema().value("defaults").toObject();
+    if (_pDefaultExpressionManager == nullptr)
+    {
+        return;
+    }
+
+    const QJsonObject defaults = _pSettingsModel->adapterData(_pDefaultExpressionManager->adapterId())
+                                   ->dataPointSchema()
+                                   .value("defaults")
+                                   .toObject();
     if (defaults.isEmpty())
     {
         return;
     }
 
     /* Disconnect any pending connection from a previous session before installing a new one */
-    QObject::disconnect(_pAdapterManager, &AdapterManager::buildExpressionResult, this,
+    QObject::disconnect(_pDefaultExpressionManager, &AdapterManager::buildExpressionResult, this,
                         &RegisterDialog::onDefaultExpressionBuilt);
-    connect(_pAdapterManager, &AdapterManager::buildExpressionResult, this, &RegisterDialog::onDefaultExpressionBuilt,
-            Qt::SingleShotConnection);
+    connect(_pDefaultExpressionManager, &AdapterManager::buildExpressionResult, this,
+            &RegisterDialog::onDefaultExpressionBuilt, Qt::SingleShotConnection);
 
     QJsonObject addressFields = defaults;
     const QString dataType = addressFields.take(QStringLiteral("dataType")).toString();
-    _pAdapterManager->buildExpression(addressFields, dataType, 0);
+    _pDefaultExpressionManager->buildExpression(addressFields, dataType, 0);
 }
 
 /*!

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -8,6 +8,7 @@
 
 /* Forward declaration */
 class GraphDataModel;
+class AdapterHub;
 class AdapterManager;
 class SettingsModel;
 class RegisterValueAxisDelegate;
@@ -25,7 +26,7 @@ class RegisterDialog : public QDialog
 public:
     explicit RegisterDialog(GraphDataModel* pGraphDataModel,
                             SettingsModel* pSettingsModel,
-                            AdapterManager* pAdapterManager,
+                            AdapterHub* pAdapterHub,
                             QWidget* parent = nullptr);
     ~RegisterDialog();
 
@@ -41,13 +42,15 @@ private slots:
 
 private:
     int selectedRowAfterDelete(int deletedStartIndex, int rowCnt);
+    AdapterManager* defaultExpressionManager() const;
     static bool sortRegistersLastFirst(const QModelIndex& s1, const QModelIndex& s2);
 
     Ui::RegisterDialog* _pUi;
 
     GraphDataModel* _pGraphDataModel;
     SettingsModel* _pSettingsModel;
-    AdapterManager* _pAdapterManager;
+    AdapterHub* _pAdapterHub;
+    AdapterManager* _pDefaultExpressionManager;
 
     CenteredBoxProxyStyle _centeredBoxStyle;
 

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -141,6 +141,18 @@ QList<deviceId_t> SettingsModel::deviceListForAdapter(const QString& adapterId)
     return list;
 }
 
+/*! \brief Return the adapter ID that owns the given device.
+ *
+ * When the device is unknown, the adapter ID of a default-constructed Device
+ * ("modbus") is returned without inserting a new device entry.
+ * \param devId  The device identifier.
+ * \return The adapter ID string associated with the device.
+ */
+QString SettingsModel::adapterIdForDevice(deviceId_t devId) const
+{
+    return _devices.value(devId).adapterId();
+}
+
 void SettingsModel::setWriteDuringLog(bool bState)
 {
     if (_bWriteDuringLog != bState)

--- a/src/models/settingsmodel.h
+++ b/src/models/settingsmodel.h
@@ -35,6 +35,7 @@ public:
 
     QList<deviceId_t> deviceList();
     QList<deviceId_t> deviceListForAdapter(const QString& adapterId);
+    QString adapterIdForDevice(deviceId_t devId) const;
 
     const AdapterData* adapterData(const QString& adapterId);
     QStringList adapterIds() const;

--- a/src/util/expressionchecker.cpp
+++ b/src/util/expressionchecker.cpp
@@ -17,10 +17,12 @@ void ExpressionChecker::setExpression(const QString& expr)
     _expectedDeviceIdList.clear();
     _descriptions.clear();
     _addresses.clear();
+    _deviceIds.clear();
     for (DataPoint const& reg : std::as_const(registerList))
     {
         _descriptions.append(reg.description());
         _addresses.append(reg.address());
+        _deviceIds.append(reg.deviceId());
 
         if (!_expectedDeviceIdList.contains(reg.deviceId()))
         {
@@ -49,6 +51,11 @@ QStringList ExpressionChecker::descriptions() const
 QStringList ExpressionChecker::addresses() const
 {
     return _addresses;
+}
+
+QList<deviceId_t> ExpressionChecker::deviceIds() const
+{
+    return _deviceIds;
 }
 
 qsizetype ExpressionChecker::requiredValueCount()

--- a/src/util/expressionchecker.h
+++ b/src/util/expressionchecker.h
@@ -16,6 +16,7 @@ public:
     QString expression(void);
     QStringList descriptions() const;
     QStringList addresses() const;
+    QList<deviceId_t> deviceIds() const;
     qsizetype requiredValueCount();
 
     bool checkForDevices(QList<deviceId_t> const& deviceIdList);
@@ -40,6 +41,7 @@ private:
 
     QStringList _descriptions;
     QStringList _addresses;
+    QList<deviceId_t> _deviceIds;
 
     bool _bValid;
     double _result;

--- a/tests/ProtocolAdapter/CMakeLists.txt
+++ b/tests/ProtocolAdapter/CMakeLists.txt
@@ -3,6 +3,7 @@ add_xtest(tst_adapterclient)
 add_xtest(tst_adapterprocess)
 add_xtest(tst_adaptermanager)
 add_xtest(tst_adapterdiscovery)
+add_xtest(tst_adapterhub)
 
 target_compile_definitions(tst_adapterprocess PRIVATE
     DUMMY_ADAPTER_EXECUTABLE="$<TARGET_FILE:dummymodbusadapter>"

--- a/tests/ProtocolAdapter/tst_adapterhub.cpp
+++ b/tests/ProtocolAdapter/tst_adapterhub.cpp
@@ -1,0 +1,70 @@
+#include "tst_adapterhub.h"
+
+#include "ProtocolAdapter/adapterhub.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+/*!
+ * \brief A single pending adapter that fails to start must only report sessionError.
+ *
+ * Matches today's single-adapter (modbus-only) behavior and must stay correct.
+ */
+void TestAdapterHub::errorOnSingleAdapterEmitsErrorOnly()
+{
+    AdapterHub hub;
+    hub._pendingStartAdapters.insert(QStringLiteral("modbus"));
+
+    QSignalSpy startedSpy(&hub, &AdapterHub::sessionStarted);
+    QSignalSpy errorSpy(&hub, &AdapterHub::sessionError);
+
+    hub.onManagerSessionError(QStringLiteral("modbus"), QStringLiteral("boom"));
+
+    QCOMPARE(errorSpy.count(), 1);
+    QCOMPARE(startedSpy.count(), 0);
+}
+
+/*!
+ * \brief Regression test: a sibling adapter having already started must not turn a
+ * later sibling's failure into a reported success.
+ */
+void TestAdapterHub::errorOnLastPendingAdapterDoesNotEmitSessionStarted()
+{
+    AdapterHub hub;
+    hub._pendingStartAdapters.insert(QStringLiteral("modbus"));
+    hub._pendingStartAdapters.insert(QStringLiteral("sim"));
+
+    QSignalSpy startedSpy(&hub, &AdapterHub::sessionStarted);
+    QSignalSpy errorSpy(&hub, &AdapterHub::sessionError);
+
+    /* First adapter starts successfully - still waiting on "sim" */
+    hub.onManagerSessionStarted(QStringLiteral("modbus"));
+    QCOMPARE(startedSpy.count(), 0);
+
+    /* Second (last pending) adapter fails to start */
+    hub.onManagerSessionError(QStringLiteral("sim"), QStringLiteral("boom"));
+
+    QCOMPARE(errorSpy.count(), 1);
+    QCOMPARE(startedSpy.count(), 0);
+}
+
+/*!
+ * \brief Happy-path guard: sessionStarted is still emitted exactly once when all
+ * pending adapters start successfully.
+ */
+void TestAdapterHub::allAdaptersSucceedEmitsSessionStartedOnce()
+{
+    AdapterHub hub;
+    hub._pendingStartAdapters.insert(QStringLiteral("modbus"));
+    hub._pendingStartAdapters.insert(QStringLiteral("sim"));
+
+    QSignalSpy startedSpy(&hub, &AdapterHub::sessionStarted);
+
+    hub.onManagerSessionStarted(QStringLiteral("modbus"));
+    QCOMPARE(startedSpy.count(), 0);
+
+    hub.onManagerSessionStarted(QStringLiteral("sim"));
+    QCOMPARE(startedSpy.count(), 1);
+}
+
+QTEST_GUILESS_MAIN(TestAdapterHub)

--- a/tests/ProtocolAdapter/tst_adapterhub.h
+++ b/tests/ProtocolAdapter/tst_adapterhub.h
@@ -1,0 +1,15 @@
+#ifndef TST_ADAPTERHUB_H
+#define TST_ADAPTERHUB_H
+
+#include <QObject>
+
+class TestAdapterHub : public QObject
+{
+    Q_OBJECT
+private slots:
+    void errorOnSingleAdapterEmitsErrorOnly();
+    void errorOnLastPendingAdapterDoesNotEmitSessionStarted();
+    void allAdaptersSucceedEmitsSessionStartedOnce();
+};
+
+#endif // TST_ADAPTERHUB_H

--- a/tests/dialogs/mockadapterhub.h
+++ b/tests/dialogs/mockadapterhub.h
@@ -1,0 +1,41 @@
+#ifndef MOCKADAPTERHUB_H
+#define MOCKADAPTERHUB_H
+
+#include "ProtocolAdapter/adapterhub.h"
+#include "ProtocolAdapter/adaptermanager.h"
+
+#include <QMap>
+
+/*!
+ * \brief Test double for AdapterHub.
+ *
+ * Holds externally created (mock) adapter managers and serves them via the
+ * regular lookup interface without starting any adapter infrastructure.
+ */
+class MockAdapterHub : public AdapterHub
+{
+public:
+    explicit MockAdapterHub(QObject* parent = nullptr) : AdapterHub(parent)
+    {
+    }
+
+    void addManager(const QString& id, AdapterManager* pManager)
+    {
+        _managers.insert(id, pManager);
+    }
+
+    AdapterManager* adapterManager(const QString& id) const override
+    {
+        return _managers.value(id, nullptr);
+    }
+
+    QStringList adapterIds() const override
+    {
+        return _managers.keys();
+    }
+
+private:
+    QMap<QString, AdapterManager*> _managers;
+};
+
+#endif // MOCKADAPTERHUB_H

--- a/tests/dialogs/mockadapterhub.h
+++ b/tests/dialogs/mockadapterhub.h
@@ -34,6 +34,34 @@ public:
         return _managers.keys();
     }
 
+    bool isAdapterReady() const override
+    {
+        if (_managers.isEmpty())
+        {
+            return false;
+        }
+        for (const AdapterManager* pManager : _managers)
+        {
+            if (!pManager->isAdapterReady())
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool isAdapterIdle() const override
+    {
+        for (const AdapterManager* pManager : _managers)
+        {
+            if (!pManager->isAdapterIdle())
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
 private:
     QMap<QString, AdapterManager*> _managers;
 };

--- a/tests/dialogs/tst_adapterdevicesettings.cpp
+++ b/tests/dialogs/tst_adapterdevicesettings.cpp
@@ -703,4 +703,24 @@ void TestAdapterDeviceSettings::twoAdaptersWithSameDefaultDeviceIdShowsSingleTab
     QVERIFY(model.hasDevice(1));
 }
 
+void TestAdapterDeviceSettings::existingDeviceAdapterIdMatchesConfigOnOpen()
+{
+    SettingsModel model;
+
+    // Use id=2: SettingsModel pre-populates device 1 (cFirstDeviceId), so use a
+    // different id to genuinely exercise the "not yet in model" path.
+    QJsonObject dev;
+    dev["id"] = 2;
+    setupAdapter(model, "adapterB", QJsonArray{ dev });
+
+    // Device is not yet registered in the model — AdapterDeviceSettings must add it
+    // and assign it the adapter its config came from, not Device's constructor default.
+    QVERIFY(!model.hasDevice(2));
+
+    AdapterDeviceSettings w(&model);
+
+    QVERIFY(model.hasDevice(2));
+    QCOMPARE(model.deviceSettings(2)->adapterId(), QStringLiteral("adapterB"));
+}
+
 QTEST_MAIN(TestAdapterDeviceSettings)

--- a/tests/dialogs/tst_adapterdevicesettings.h
+++ b/tests/dialogs/tst_adapterdevicesettings.h
@@ -31,6 +31,7 @@ private slots:
     void addTabAfterIdEditDoesNotDuplicate();
     void acceptValuesClearsDevicesForEmptiedAdapter();
     void twoAdaptersWithSameDefaultDeviceIdShowsSingleTab();
+    void existingDeviceAdapterIdMatchesConfigOnOpen();
 #if 0
     void editingDeviceIdInSchemaFormUpdatesCorrectModelDevice();
 #endif

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -98,6 +98,8 @@ QJsonObject TestAddRegisterWidget::buildSimRegisterSchema()
 void TestAddRegisterWidget::init()
 {
     _settingsModel.removeAllDevice();
+    /* Drop the sim adapter data a previous multi-adapter test may have registered */
+    _settingsModel.removeAdapter(QStringLiteral("sim"));
     _settingsModel.setAdapterDataPointSchema("modbus", buildTestRegisterSchema());
     _settingsModel.deviceSettings(Device::cFirstDeviceId)->setAdapterId("modbus");
 
@@ -253,14 +255,14 @@ void TestAddRegisterWidget::buildExpressionDoesNotInterfereWithOtherConnections(
 
 void TestAddRegisterWidget::adapterComboHiddenWithSingleAdapter()
 {
-    QVERIFY(!_pRegWidget->_pUi->cmbAdapter->isVisibleTo(_pRegWidget));
+    QVERIFY(_pRegWidget->_pUi->cmbAdapter->isHidden());
 }
 
 void TestAddRegisterWidget::adapterComboListsAdapters()
 {
     addSimAdapter();
 
-    QVERIFY(_pRegWidget->_pUi->cmbAdapter->isVisibleTo(_pRegWidget));
+    QVERIFY(!_pRegWidget->_pUi->cmbAdapter->isHidden());
     QCOMPARE(_pRegWidget->_pUi->cmbAdapter->count(), 2);
 
     /* Adapter IDs are listed alphabetically; label falls back to the ID without describe data */

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -72,6 +72,29 @@ QJsonObject TestAddRegisterWidget::buildTestRegisterSchema()
     return schema;
 }
 
+QJsonObject TestAddRegisterWidget::buildSimRegisterSchema()
+{
+    QJsonObject channelField;
+    channelField["type"] = QStringLiteral("integer");
+    channelField["title"] = QStringLiteral("Channel");
+    channelField["minimum"] = 0;
+
+    QJsonObject properties;
+    properties["channel"] = channelField;
+
+    QJsonObject addressSchema;
+    addressSchema["type"] = QStringLiteral("object");
+    addressSchema["properties"] = properties;
+
+    QJsonObject defaults;
+    defaults["channel"] = 3;
+
+    QJsonObject schema;
+    schema["addressSchema"] = addressSchema;
+    schema["defaults"] = defaults;
+    return schema;
+}
+
 void TestAddRegisterWidget::init()
 {
     _settingsModel.removeAllDevice();
@@ -79,7 +102,9 @@ void TestAddRegisterWidget::init()
     _settingsModel.deviceSettings(Device::cFirstDeviceId)->setAdapterId("modbus");
 
     _pMockAdapterManager = new MockAdapterManager(&_settingsModel);
-    _pRegWidget = new AddRegisterWidget(&_settingsModel, QStringLiteral("modbus"), _pMockAdapterManager);
+    _pMockHub = new MockAdapterHub();
+    _pMockHub->addManager(QStringLiteral("modbus"), _pMockAdapterManager);
+    _pRegWidget = new AddRegisterWidget(&_settingsModel, _pMockHub);
 }
 
 void TestAddRegisterWidget::cleanup()
@@ -88,6 +113,28 @@ void TestAddRegisterWidget::cleanup()
     _pRegWidget = nullptr;
     delete _pMockAdapterManager;
     _pMockAdapterManager = nullptr;
+    delete _pMockSimAdapterManager;
+    _pMockSimAdapterManager = nullptr;
+    delete _pMockHub;
+    _pMockHub = nullptr;
+}
+
+/*!
+ * \brief Register a second ("sim") adapter and rebuild the widget with both adapters.
+ */
+void TestAddRegisterWidget::addSimAdapter()
+{
+    _settingsModel.setAdapterDataPointSchema("sim", buildSimRegisterSchema());
+
+    QJsonObject describeResult;
+    describeResult["name"] = QStringLiteral("Simulator");
+    _settingsModel.updateAdapterFromDescribe(QStringLiteral("sim"), describeResult);
+
+    _pMockSimAdapterManager = new MockAdapterManager(&_settingsModel, QStringLiteral("sim"));
+    _pMockHub->addManager(QStringLiteral("sim"), _pMockSimAdapterManager);
+
+    delete _pRegWidget;
+    _pRegWidget = new AddRegisterWidget(&_settingsModel, _pMockHub);
 }
 
 void TestAddRegisterWidget::registerDefault()
@@ -202,6 +249,69 @@ void TestAddRegisterWidget::buildExpressionDoesNotInterfereWithOtherConnections(
 
     /* The persistent secondary connection still fires on subsequent emissions */
     QCOMPARE(secondaryReceiveCount, 2);
+}
+
+void TestAddRegisterWidget::adapterComboHiddenWithSingleAdapter()
+{
+    QVERIFY(!_pRegWidget->_pUi->cmbAdapter->isVisibleTo(_pRegWidget));
+}
+
+void TestAddRegisterWidget::adapterComboListsAdapters()
+{
+    addSimAdapter();
+
+    QVERIFY(_pRegWidget->_pUi->cmbAdapter->isVisibleTo(_pRegWidget));
+    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->count(), 2);
+
+    /* Adapter IDs are listed alphabetically; label falls back to the ID without describe data */
+    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemText(0), QStringLiteral("modbus"));
+    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemData(0).toString(), QStringLiteral("modbus"));
+    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemText(1), QStringLiteral("Simulator"));
+    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemData(1).toString(), QStringLiteral("sim"));
+}
+
+void TestAddRegisterWidget::switchAdapterRebuildsSchema()
+{
+    addSimAdapter();
+
+    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+
+    QVERIFY(_pRegWidget->_addressSchema["properties"].toObject().contains(QStringLiteral("channel")));
+    QCOMPARE(_pRegWidget->_dataPointDefaults["channel"].toInt(), 3);
+    QCOMPARE(_pRegWidget->_pAddressForm->values()["channel"].toInt(), 3);
+}
+
+void TestAddRegisterWidget::buildExpressionRoutedToSelectedAdapter()
+{
+    _settingsModel.addDevice(2);
+    _settingsModel.deviceSettings(2)->setAdapterId("sim");
+
+    addSimAdapter();
+
+    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+
+    QSignalSpy spy(_pRegWidget, &AddRegisterWidget::graphDataConfigured);
+    clickAdd();
+
+    QCOMPARE(_pMockSimAdapterManager->buildCalls.size(), 1);
+    QCOMPARE(_pMockAdapterManager->buildCalls.size(), 0);
+
+    _pMockSimAdapterManager->injectBuildExpressionResult(QStringLiteral("${c3}"));
+    QCOMPARE(spy.count(), 1);
+}
+
+void TestAddRegisterWidget::btnAddDisabledWhenSelectedAdapterHasNoDevices()
+{
+    addSimAdapter();
+
+    /* Only device 1 exists and it belongs to the modbus adapter */
+    QVERIFY(_pRegWidget->_pUi->btnAdd->isEnabled());
+
+    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    QVERIFY(!_pRegWidget->_pUi->btnAdd->isEnabled());
+
+    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(0);
+    QVERIFY(_pRegWidget->_pUi->btnAdd->isEnabled());
 }
 
 void TestAddRegisterWidget::clickAdd()

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -3,6 +3,7 @@
 #define TST_ADDREGISTERWIDGET_H
 
 #include "ProtocolAdapter/adaptermanager.h"
+#include "mockadapterhub.h"
 #include "models/graphdata.h"
 #include "models/settingsmodel.h"
 
@@ -29,8 +30,10 @@ public:
         deviceId_t deviceId;
     };
 
-    explicit MockAdapterManager(SettingsModel* pSettingsModel, QObject* parent = nullptr)
-        : AdapterManager(QStringLiteral("modbus"), QString(), pSettingsModel, parent)
+    explicit MockAdapterManager(SettingsModel* pSettingsModel,
+                                const QString& adapterId = QStringLiteral("modbus"),
+                                QObject* parent = nullptr)
+        : AdapterManager(adapterId, QString(), pSettingsModel, parent)
     {
     }
 
@@ -68,14 +71,24 @@ private slots:
     void buildExpressionEmptyResponseIgnored();
     void buildExpressionDoesNotInterfereWithOtherConnections();
 
+    void adapterComboHiddenWithSingleAdapter();
+    void adapterComboListsAdapters();
+    void switchAdapterRebuildsSchema();
+    void buildExpressionRoutedToSelectedAdapter();
+    void btnAddDisabledWhenSelectedAdapterHasNoDevices();
+
 private:
     void clickAdd();
     void addRegister(GraphData& graphData, const QString& expression);
+    void addSimAdapter();
     static QJsonObject buildAddressSchema();
     static QJsonObject buildTestRegisterSchema();
+    static QJsonObject buildSimRegisterSchema();
 
     SettingsModel _settingsModel;
+    MockAdapterHub* _pMockHub{ nullptr };
     MockAdapterManager* _pMockAdapterManager{ nullptr };
+    MockAdapterManager* _pMockSimAdapterManager{ nullptr };
     AddRegisterWidget* _pRegWidget{ nullptr };
 };
 

--- a/tests/dialogs/tst_expressionsdialog.cpp
+++ b/tests/dialogs/tst_expressionsdialog.cpp
@@ -2,9 +2,13 @@
 #include "tst_expressionsdialog.h"
 
 #include "dialogs/expressionsdialog.h"
+#include "models/device.h"
 #include "models/graphdata.h"
 #include "models/graphdatamodel.h"
+#include "models/settingsmodel.h"
 
+#include <QComboBox>
+#include <QLabel>
 #include <QPlainTextEdit>
 #include <QTableWidget>
 #include <QTest>
@@ -13,14 +17,45 @@ void TestExpressionsDialog::init()
 {
     _pGraphDataModel = new GraphDataModel(this);
     _pGraphDataModel->add(GraphData());
-    _pMockAdapterManager = new MockAdapterManager(this);
-    _pDialog = new ExpressionsDialog(_pGraphDataModel, GraphIdx(0), _pMockAdapterManager);
+
+    _pSettingsModel = new SettingsModel(this);
+    _pSettingsModel->deviceSettings(Device::cFirstDeviceId)->setAdapterId("modbus");
+
+    _pMockAdapterManager = new MockAdapterManager(QStringLiteral("modbus"), this);
+    _pMockHub = new MockAdapterHub(this);
+    _pMockHub->addManager(QStringLiteral("modbus"), _pMockAdapterManager);
+
+    _pDialog = new ExpressionsDialog(_pGraphDataModel, GraphIdx(0), _pMockHub, _pSettingsModel);
 }
 
 void TestExpressionsDialog::cleanup()
 {
     delete _pDialog;
     _pDialog = nullptr;
+}
+
+/*!
+ * \brief Register a second ("sim") adapter manager in the hub.
+ * \return Pointer to the created sim mock manager (owned by the test object).
+ */
+MockAdapterManager* TestExpressionsDialog::addSimAdapter()
+{
+    auto* pSimManager = new MockAdapterManager(QStringLiteral("sim"), this);
+    _pMockHub->addManager(QStringLiteral("sim"), pSimManager);
+    return pSimManager;
+}
+
+/*!
+ * \brief Recreate the dialog so it picks up hub changes made after init().
+ *
+ * Resets the modbus mock's help request counter so tests only observe requests
+ * made by the recreated dialog.
+ */
+void TestExpressionsDialog::recreateDialog()
+{
+    delete _pDialog;
+    _pMockAdapterManager->helpRequestCount = 0;
+    _pDialog = new ExpressionsDialog(_pGraphDataModel, GraphIdx(0), _pMockHub, _pSettingsModel);
 }
 
 void TestExpressionsDialog::describeDispatch_singleAddress()
@@ -87,6 +122,134 @@ void TestExpressionsDialog::describeDispatch_abortsOnExpressionChange()
 
     /* Stale A connection was cancelled — no further calls triggered */
     QCOMPARE(_pMockAdapterManager->describeCalls.size(), 2);
+}
+
+void TestExpressionsDialog::describeRoutedPerDeviceAdapter()
+{
+    _pSettingsModel->deviceSettings(2)->setAdapterId("sim");
+    MockAdapterManager* pSimManager = addSimAdapter();
+
+    auto* pEdit = _pDialog->findChild<QPlainTextEdit*>("lineExpression");
+    QVERIFY(pEdit != nullptr);
+
+    pEdit->setPlainText(QStringLiteral("${40001} + ${40002@2}"));
+
+    /* First data point belongs to device 1 (modbus adapter) */
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+    QCOMPARE(_pMockAdapterManager->describeCalls[0], QStringLiteral("${40001}"));
+    QCOMPARE(pSimManager->describeCalls.size(), 0);
+
+    _pMockAdapterManager->injectDescribeResult(QStringLiteral("Modbus reg"));
+
+    /* Second data point belongs to device 2 (sim adapter) */
+    QCOMPARE(pSimManager->describeCalls.size(), 1);
+    QCOMPARE(pSimManager->describeCalls[0], QStringLiteral("${40002@2}"));
+
+    pSimManager->injectDescribeResult(QStringLiteral("Sim reg"));
+
+    auto* pTable = _pDialog->findChild<QTableWidget*>("tblExpressionInput");
+    QVERIFY(pTable != nullptr);
+    QCOMPARE(pTable->item(0, 0)->text(), QStringLiteral("Modbus reg"));
+    QCOMPARE(pTable->item(1, 0)->text(), QStringLiteral("Sim reg"));
+
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+}
+
+void TestExpressionsDialog::describeSkipsUnavailableAdapter()
+{
+    /* Device 2 belongs to an adapter without a manager in the hub */
+    _pSettingsModel->deviceSettings(2)->setAdapterId("sim");
+
+    auto* pEdit = _pDialog->findChild<QPlainTextEdit*>("lineExpression");
+    QVERIFY(pEdit != nullptr);
+
+    pEdit->setPlainText(QStringLiteral("${40001@2} + ${40002}"));
+
+    /* Row 0 is skipped; the describe chain continues with row 1 on the modbus adapter */
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+    QCOMPARE(_pMockAdapterManager->describeCalls[0], QStringLiteral("${40002}"));
+
+    _pMockAdapterManager->injectDescribeResult(QStringLiteral("Modbus reg"));
+
+    auto* pTable = _pDialog->findChild<QTableWidget*>("tblExpressionInput");
+    QVERIFY(pTable != nullptr);
+
+    /* Skipped row keeps the parser description */
+    QCOMPARE(pTable->item(0, 0)->text(), QStringLiteral("${40001@2}, device id 2"));
+    QCOMPARE(pTable->item(1, 0)->text(), QStringLiteral("Modbus reg"));
+
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+}
+
+void TestExpressionsDialog::describeSkipsIdleAdapter()
+{
+    _pSettingsModel->deviceSettings(2)->setAdapterId("sim");
+    MockAdapterManager* pSimManager = addSimAdapter();
+    pSimManager->mockIdle = true;
+
+    auto* pEdit = _pDialog->findChild<QPlainTextEdit*>("lineExpression");
+    QVERIFY(pEdit != nullptr);
+
+    pEdit->setPlainText(QStringLiteral("${40001@2} + ${40002}"));
+
+    /* The idle sim adapter is skipped; only the modbus data point is described */
+    QCOMPARE(pSimManager->describeCalls.size(), 0);
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+    QCOMPARE(_pMockAdapterManager->describeCalls[0], QStringLiteral("${40002}"));
+}
+
+void TestExpressionsDialog::helpComboHiddenWithSingleAdapter()
+{
+    auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpAdapter");
+    QVERIFY(pHelpWidget != nullptr);
+    QVERIFY(!pHelpWidget->isVisibleTo(_pDialog));
+}
+
+void TestExpressionsDialog::helpComboVisibleWithTwoAdapters()
+{
+    addSimAdapter();
+    recreateDialog();
+
+    auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpAdapter");
+    QVERIFY(pHelpWidget != nullptr);
+    QVERIFY(pHelpWidget->isVisibleTo(_pDialog));
+
+    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpAdapter");
+    QVERIFY(pCombo != nullptr);
+    QCOMPARE(pCombo->count(), 2);
+    QCOMPARE(pCombo->itemData(0).toString(), QStringLiteral("modbus"));
+    QCOMPARE(pCombo->itemData(1).toString(), QStringLiteral("sim"));
+}
+
+void TestExpressionsDialog::helpRoutedToSelectedAdapter()
+{
+    MockAdapterManager* pSimManager = addSimAdapter();
+    recreateDialog();
+
+    auto* pInfoLabel = _pDialog->findChild<QLabel*>("lblInfo");
+    QVERIFY(pInfoLabel != nullptr);
+
+    /* The dialog requested help from the initially selected (modbus) adapter */
+    QCOMPARE(_pMockAdapterManager->helpRequestCount, 1);
+    QCOMPARE(pSimManager->helpRequestCount, 0);
+
+    _pMockAdapterManager->injectExpressionHelp(QStringLiteral("Modbus help"));
+    QCOMPARE(pInfoLabel->text(), QStringLiteral("Modbus help"));
+
+    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpAdapter");
+    QVERIFY(pCombo != nullptr);
+    pCombo->setCurrentIndex(1);
+
+    /* Selecting the sim adapter clears the help text and requests its help */
+    QCOMPARE(pSimManager->helpRequestCount, 1);
+    QCOMPARE(pInfoLabel->text(), QString());
+
+    pSimManager->injectExpressionHelp(QStringLiteral("Sim help"));
+    QCOMPARE(pInfoLabel->text(), QStringLiteral("Sim help"));
+
+    /* A late response from the deselected modbus adapter is ignored */
+    _pMockAdapterManager->injectExpressionHelp(QStringLiteral("Stale modbus help"));
+    QCOMPARE(pInfoLabel->text(), QStringLiteral("Sim help"));
 }
 
 QTEST_MAIN(TestExpressionsDialog)

--- a/tests/dialogs/tst_expressionsdialog.cpp
+++ b/tests/dialogs/tst_expressionsdialog.cpp
@@ -200,9 +200,11 @@ void TestExpressionsDialog::describeSkipsIdleAdapter()
 
 void TestExpressionsDialog::helpComboHiddenWithSingleAdapter()
 {
+    /* Use isHidden(): the surrounding info panel (widgetInfo) starts collapsed,
+     * so visibility relative to the dialog is always false */
     auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpAdapter");
     QVERIFY(pHelpWidget != nullptr);
-    QVERIFY(!pHelpWidget->isVisibleTo(_pDialog));
+    QVERIFY(pHelpWidget->isHidden());
 }
 
 void TestExpressionsDialog::helpComboVisibleWithTwoAdapters()
@@ -212,7 +214,7 @@ void TestExpressionsDialog::helpComboVisibleWithTwoAdapters()
 
     auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpAdapter");
     QVERIFY(pHelpWidget != nullptr);
-    QVERIFY(pHelpWidget->isVisibleTo(_pDialog));
+    QVERIFY(!pHelpWidget->isHidden());
 
     auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpAdapter");
     QVERIFY(pCombo != nullptr);

--- a/tests/dialogs/tst_expressionsdialog.h
+++ b/tests/dialogs/tst_expressionsdialog.h
@@ -3,6 +3,7 @@
 #define TST_EXPRESSIONSDIALOG_H
 
 #include "ProtocolAdapter/adaptermanager.h"
+#include "mockadapterhub.h"
 
 #include <QJsonObject>
 #include <QObject>
@@ -10,16 +11,16 @@
 /*!
  * \brief Test double for AdapterManager.
  *
- * Captures describeDataPoint() calls and provides an inject helper to simulate
- * the adapter.describeDataPoint response without a real adapter process.
+ * Captures describeDataPoint() and requestExpressionHelp() calls and provides
+ * inject helpers to simulate the adapter responses without a real adapter process.
  */
 class MockAdapterManager : public AdapterManager
 {
     Q_OBJECT
 
 public:
-    explicit MockAdapterManager(QObject* parent = nullptr)
-        : AdapterManager(QStringLiteral("modbus"), QString(), nullptr, parent)
+    explicit MockAdapterManager(const QString& adapterId = QStringLiteral("modbus"), QObject* parent = nullptr)
+        : AdapterManager(adapterId, QString(), nullptr, parent)
     {
     }
 
@@ -30,11 +31,12 @@ public:
 
     void requestExpressionHelp() override
     {
+        helpRequestCount++;
     }
 
     bool isAdapterIdle() const override
     {
-        return false;
+        return mockIdle;
     }
 
     //! Simulate the adapter returning a description for the last requested data point.
@@ -45,11 +47,20 @@ public:
         emit describeDataPointResult(result);
     }
 
+    //! Simulate the adapter returning expression help text.
+    void injectExpressionHelp(const QString& helpText)
+    {
+        emit expressionHelpResult(helpText);
+    }
+
     QStringList describeCalls;
+    int helpRequestCount{ 0 };
+    bool mockIdle{ false };
 };
 
 class GraphDataModel;
 class ExpressionsDialog;
+class SettingsModel;
 
 class TestExpressionsDialog : public QObject
 {
@@ -63,8 +74,20 @@ private slots:
     void describeDispatch_multipleAddresses();
     void describeDispatch_abortsOnExpressionChange();
 
+    void describeRoutedPerDeviceAdapter();
+    void describeSkipsUnavailableAdapter();
+    void describeSkipsIdleAdapter();
+    void helpComboHiddenWithSingleAdapter();
+    void helpComboVisibleWithTwoAdapters();
+    void helpRoutedToSelectedAdapter();
+
 private:
+    MockAdapterManager* addSimAdapter();
+    void recreateDialog();
+
     GraphDataModel* _pGraphDataModel{ nullptr };
+    SettingsModel* _pSettingsModel{ nullptr };
+    MockAdapterHub* _pMockHub{ nullptr };
     MockAdapterManager* _pMockAdapterManager{ nullptr };
     ExpressionsDialog* _pDialog{ nullptr };
 };

--- a/tests/util/tst_expressionchecker.cpp
+++ b/tests/util/tst_expressionchecker.cpp
@@ -44,6 +44,19 @@ void TestExpressionChecker::addressesMatchExpression()
     QCOMPARE(addrs, expAddresses);
 }
 
+void TestExpressionChecker::deviceIdsMatchAddresses()
+{
+    ExpressionChecker checker;
+
+    checker.setExpression("${40001} + ${40002@2}");
+
+    QCOMPARE(checker.addresses(), QStringList() << "${40001}" << "${40002@2}");
+
+    QList<deviceId_t> expDeviceIds;
+    expDeviceIds << static_cast<deviceId_t>(1) << static_cast<deviceId_t>(2);
+    QCOMPARE(checker.deviceIds(), expDeviceIds);
+}
+
 void TestExpressionChecker::expressionIsValid()
 {
     ExpressionChecker checker;

--- a/tests/util/tst_expressionchecker.h
+++ b/tests/util/tst_expressionchecker.h
@@ -1,4 +1,7 @@
 
+#ifndef TST_EXPRESSIONCHECKER_H
+#define TST_EXPRESSIONCHECKER_H
+
 #include <QObject>
 
 class TestExpressionChecker : public QObject
@@ -21,3 +24,5 @@ private slots:
 
 private:
 };
+
+#endif // TST_EXPRESSIONCHECKER_H

--- a/tests/util/tst_expressionchecker.h
+++ b/tests/util/tst_expressionchecker.h
@@ -11,6 +11,7 @@ private slots:
 
     void dataIsPrimed();
     void addressesMatchExpression();
+    void deviceIdsMatchAddresses();
     void expressionIsValid();
     void expressionHasSyntaxError();
     void valueErrorIsNotSyntaxError();


### PR DESCRIPTION
Make the add-register popup and expressions dialog multi-adapter aware
instead of hardwired to the modbus adapter:

- AddRegisterWidget: adapter dropdown (hidden with a single adapter)
  rebuilds the schema form and routes buildExpression to the selected
  adapter's manager
- ExpressionsDialog: describeDataPoint is routed per data point to the
  adapter owning its device; unavailable adapters are skipped. The info
  panel gains an adapter selector for per-adapter expression help
- Dialogs now receive AdapterHub instead of a single AdapterManager
- New helpers: AdapterHub::adapterIds(), SettingsModel::adapterIdForDevice(),
  ExpressionChecker::deviceIds()

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VV7FK2h8HEYq71BqTNcY4G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register and expression dialogs now use hub-discovered adapter lists, enabling adapter switching and (when applicable) a selectable help adapter.
  * Added adapter/device-aware routing via new Settings and expression checker device-ID support.
* **Bug Fixes**
  * Improved adapter session error handling so session start events aren’t emitted on failure.
  * Per-device expression description and default-expression flows now use the correct adapter and refresh address/schema when switching.
* **Tests**
  * Added adapter hub tests and expanded multi-adapter UI/dialog coverage, including new ExpressionChecker device-ID verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->