### PR TITLE
Harden MBC parser for string and unknown register types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 The latest *ModbusScope* installer or standalone version can always be downloaded from the [release page](https://github.com/ModbusScope/ModbusScope/releases).
 
-## [v5.0.0](https://github.com/ModbusScope/ModbusScope/releases/tag/5.0.0) (29/05/2026)
+## Unreleased
 
 ### Added
 
@@ -8,6 +8,10 @@ The latest *ModbusScope* installer or standalone version can always be downloade
   * The adapter is started and managed by ModbusScope
   * Adapter configuration is stored in the project file
 * Show a message in the graph area when no registers are configured yet
+
+### Fixed
+
+* Fix MBC import aborting entirely when the file contains a string register; string registers are now shown disabled instead
 
 ### Changed
 

--- a/src/MbcInterface/mbcdatatype.cpp
+++ b/src/MbcInterface/mbcdatatype.cpp
@@ -1,6 +1,6 @@
 #include "mbcdatatype.h"
 
-const MbcDataType::TypeSettings MbcDataType::cDataTypes[MbcDataType::cTypeCount] =
+const MbcDataType::TypeSettings MbcDataType::cDataTypes[] =
 {
     /*                   32-bit  supported */
     /* UNSIGNED_16 */ {  false,  true      },
@@ -10,6 +10,9 @@ const MbcDataType::TypeSettings MbcDataType::cDataTypes[MbcDataType::cTypeCount]
     /* FLOAT_32    */ {  true,   true      },
     /* STRING      */ {  false,  false     },
 };
+
+static_assert(sizeof(MbcDataType::cDataTypes) / sizeof(MbcDataType::cDataTypes[0]) == MbcDataType::cTypeCount,
+              "cDataTypes must have one entry per Type enum value");
 
 /*!
  * \brief Whether ModbusScope can plot a register of this type.

--- a/src/MbcInterface/mbcdatatype.cpp
+++ b/src/MbcInterface/mbcdatatype.cpp
@@ -13,6 +13,8 @@ const MbcDataType::TypeSettings MbcDataType::cDataTypes[] =
 
 /*!
  * \brief Byte length of a string type such as "string50" (0 when not a sized string).
+ * \param strType The string representation of the type.
+ * \return The byte length, or 0 if not a sized string.
  */
 quint32 MbcDataType::stringByteLength(const QString& strType)
 {

--- a/src/MbcInterface/mbcdatatype.cpp
+++ b/src/MbcInterface/mbcdatatype.cpp
@@ -10,3 +10,26 @@ const MbcDataType::TypeSettings MbcDataType::cDataTypes[MbcDataType::cTypeCount]
     /* FLOAT_32    */ {  true,   true      },
     /* STRING      */ {  false,  false     },
 };
+
+/*!
+ * \brief Whether ModbusScope can plot a register of this type.
+ */
+bool MbcDataType::isSupported(MbcDataType::Type type)
+{
+    return cDataTypes[static_cast<int>(type)].bSupported;
+}
+
+/*!
+ * \brief Byte length of a string type such as "string50" (0 when not a sized string).
+ */
+quint32 MbcDataType::stringByteLength(const QString& strType)
+{
+    if (!strType.startsWith("string"))
+    {
+        return 0;
+    }
+
+    bool bOk = false;
+    const quint32 bytes = strType.mid(6).toUInt(&bOk);
+    return bOk ? bytes : 0;
+}

--- a/src/MbcInterface/mbcdatatype.cpp
+++ b/src/MbcInterface/mbcdatatype.cpp
@@ -12,14 +12,6 @@ const MbcDataType::TypeSettings MbcDataType::cDataTypes[] =
 };
 
 /*!
- * \brief Whether ModbusScope can plot a register of this type.
- */
-bool MbcDataType::isSupported(MbcDataType::Type type)
-{
-    return cDataTypes[static_cast<int>(type)].bSupported;
-}
-
-/*!
  * \brief Byte length of a string type such as "string50" (0 when not a sized string).
  */
 quint32 MbcDataType::stringByteLength(const QString& strType)

--- a/src/MbcInterface/mbcdatatype.cpp
+++ b/src/MbcInterface/mbcdatatype.cpp
@@ -11,9 +11,6 @@ const MbcDataType::TypeSettings MbcDataType::cDataTypes[] =
     /* STRING      */ {  false,  false     },
 };
 
-static_assert(sizeof(MbcDataType::cDataTypes) / sizeof(MbcDataType::cDataTypes[0]) == MbcDataType::cTypeCount,
-              "cDataTypes must have one entry per Type enum value");
-
 /*!
  * \brief Whether ModbusScope can plot a register of this type.
  */

--- a/src/MbcInterface/mbcdatatype.cpp
+++ b/src/MbcInterface/mbcdatatype.cpp
@@ -1,11 +1,12 @@
 #include "mbcdatatype.h"
 
-const MbcDataType::TypeSettings MbcDataType::cDataTypes[] =
+const MbcDataType::TypeSettings MbcDataType::cDataTypes[MbcDataType::cTypeCount] =
 {
-    /* UNSIGNED_16 */ {false},
-    /* SIGNED_16   */ {false},
-    /* UNSIGNED_32 */ {true},
-    /* SIGNED_32   */ {true},
-    /* FLOAT_32    */ {true},
-    /* STRING      */ {false},
+    /*                   32-bit  supported */
+    /* UNSIGNED_16 */ {  false,  true      },
+    /* SIGNED_16   */ {  false,  true      },
+    /* UNSIGNED_32 */ {  true,   true      },
+    /* SIGNED_32   */ {  true,   true      },
+    /* FLOAT_32    */ {  true,   true      },
+    /* STRING      */ {  false,  false     },
 };

--- a/src/MbcInterface/mbcdatatype.cpp
+++ b/src/MbcInterface/mbcdatatype.cpp
@@ -7,4 +7,5 @@ const MbcDataType::TypeSettings MbcDataType::cDataTypes[] =
     /* UNSIGNED_32 */ {true},
     /* SIGNED_32   */ {true},
     /* FLOAT_32    */ {true},
+    /* STRING      */ {false},
 };

--- a/src/MbcInterface/mbcdatatype.h
+++ b/src/MbcInterface/mbcdatatype.h
@@ -18,7 +18,8 @@ public:
         STRING = 5,
     };
 
-    //! Number of Type enum values; keep cDataTypes in mbcdatatype.cpp the same length.
+    //! Number of Type enum values; cDataTypes in mbcdatatype.cpp is statically asserted
+    //! to have this many entries.
     static const int cTypeCount = static_cast<int>(Type::STRING) + 1;
 
     static bool is32Bit(MbcDataType::Type type)
@@ -106,7 +107,10 @@ private:
         bool bSupported;
     };
 
-    static const TypeSettings cDataTypes[cTypeCount];
+    //! Deliberately unsized (extern array of unknown bound): a fixed bound here would
+    //! let clang-tidy's cppcoreguidelines-pro-bounds-constant-array-index treat this as
+    //! a bounds-checkable array and flag the runtime-indexed lookups above.
+    static const TypeSettings cDataTypes[];
 };
 
 

--- a/src/MbcInterface/mbcdatatype.h
+++ b/src/MbcInterface/mbcdatatype.h
@@ -23,13 +23,17 @@ public:
         return cDataTypes[static_cast<int>(type)].b32Bit;
     }
 
-    //! \brief Whether ModbusScope can plot a register of this type.
-    //!
-    //! Kept inline (like is32Bit() above) rather than in mbcdatatype.cpp: defining it
-    //! out-of-line puts it in the same translation unit as cDataTypes's definition,
-    //! where the array's size becomes visible and clang-tidy's
-    //! cppcoreguidelines-pro-bounds-constant-array-index flags this runtime-indexed
-    //! lookup.
+    /*!
+     * \brief Whether ModbusScope can plot a register of this type.
+     *
+     * Kept inline (like is32Bit() above) rather than in mbcdatatype.cpp: defining it
+     * out-of-line puts it in the same translation unit as cDataTypes's definition,
+     * where the array's size becomes visible and clang-tidy's
+     * cppcoreguidelines-pro-bounds-constant-array-index flags this runtime-indexed
+     * lookup.
+     * \param type The data type to check.
+     * \return True when the type can be plotted.
+     */
     static bool isSupported(MbcDataType::Type type)
     {
         return cDataTypes[static_cast<int>(type)].bSupported;
@@ -113,9 +117,11 @@ private:
         bool bSupported;
     };
 
-    //! Deliberately unsized (extern array of unknown bound): a fixed bound here would
-    //! let clang-tidy's cppcoreguidelines-pro-bounds-constant-array-index treat this as
-    //! a bounds-checkable array and flag the runtime-indexed lookups above.
+    /*!
+     * Deliberately unsized (extern array of unknown bound): a fixed bound here would
+     * let clang-tidy's cppcoreguidelines-pro-bounds-constant-array-index treat this as
+     * a bounds-checkable array and flag the runtime-indexed lookups above.
+     */
     static const TypeSettings cDataTypes[];
 };
 

--- a/src/MbcInterface/mbcdatatype.h
+++ b/src/MbcInterface/mbcdatatype.h
@@ -26,24 +26,9 @@ public:
         return cDataTypes[static_cast<int>(type)].b32Bit;
     }
 
-    //! \brief Whether ModbusScope can plot a register of this type.
-    static bool isSupported(MbcDataType::Type type)
-    {
-        return cDataTypes[static_cast<int>(type)].bSupported;
-    }
+    static bool isSupported(MbcDataType::Type type);
 
-    //! \brief Byte length of a string type such as "string50" (0 when not a sized string).
-    static quint32 stringByteLength(const QString& strType)
-    {
-        if (!strType.startsWith("string"))
-        {
-            return 0;
-        }
-
-        bool bOk = false;
-        const quint32 bytes = strType.mid(6).toUInt(&bOk);
-        return bOk ? bytes : 0;
-    }
+    static quint32 stringByteLength(const QString& strType);
 
     static QString typeString(MbcDataType::Type type)
     {

--- a/src/MbcInterface/mbcdatatype.h
+++ b/src/MbcInterface/mbcdatatype.h
@@ -18,10 +18,6 @@ public:
         STRING = 5,
     };
 
-    //! Number of Type enum values; cDataTypes in mbcdatatype.cpp is statically asserted
-    //! to have this many entries.
-    static const int cTypeCount = static_cast<int>(Type::STRING) + 1;
-
     static bool is32Bit(MbcDataType::Type type)
     {
         return cDataTypes[static_cast<int>(type)].b32Bit;

--- a/src/MbcInterface/mbcdatatype.h
+++ b/src/MbcInterface/mbcdatatype.h
@@ -23,7 +23,17 @@ public:
         return cDataTypes[static_cast<int>(type)].b32Bit;
     }
 
-    static bool isSupported(MbcDataType::Type type);
+    //! \brief Whether ModbusScope can plot a register of this type.
+    //!
+    //! Kept inline (like is32Bit() above) rather than in mbcdatatype.cpp: defining it
+    //! out-of-line puts it in the same translation unit as cDataTypes's definition,
+    //! where the array's size becomes visible and clang-tidy's
+    //! cppcoreguidelines-pro-bounds-constant-array-index flags this runtime-indexed
+    //! lookup.
+    static bool isSupported(MbcDataType::Type type)
+    {
+        return cDataTypes[static_cast<int>(type)].bSupported;
+    }
 
     static quint32 stringByteLength(const QString& strType);
 

--- a/src/MbcInterface/mbcdatatype.h
+++ b/src/MbcInterface/mbcdatatype.h
@@ -18,14 +18,31 @@ public:
         STRING = 5,
     };
 
+    //! Number of Type enum values; keep cDataTypes in mbcdatatype.cpp the same length.
+    static const int cTypeCount = static_cast<int>(Type::STRING) + 1;
+
     static bool is32Bit(MbcDataType::Type type)
     {
         return cDataTypes[static_cast<int>(type)].b32Bit;
     }
 
+    //! \brief Whether ModbusScope can plot a register of this type.
     static bool isSupported(MbcDataType::Type type)
     {
-        return type != Type::STRING;
+        return cDataTypes[static_cast<int>(type)].bSupported;
+    }
+
+    //! \brief Byte length of a string type such as "string50" (0 when not a sized string).
+    static quint32 stringByteLength(const QString& strType)
+    {
+        if (!strType.startsWith("string"))
+        {
+            return 0;
+        }
+
+        bool bOk = false;
+        const quint32 bytes = strType.mid(6).toUInt(&bOk);
+        return bOk ? bytes : 0;
     }
 
     static QString typeString(MbcDataType::Type type)
@@ -48,7 +65,7 @@ public:
         }
     }
 
-    static Type convertMbcString(QString strType, bool& bOk)
+    static Type convertMbcString(const QString& strType, bool& bOk)
     {
         bOk = true;
 
@@ -101,9 +118,10 @@ private:
     struct TypeSettings
     {
         bool b32Bit;
+        bool bSupported;
     };
 
-    static const TypeSettings cDataTypes[];
+    static const TypeSettings cDataTypes[cTypeCount];
 };
 
 

--- a/src/MbcInterface/mbcdatatype.h
+++ b/src/MbcInterface/mbcdatatype.h
@@ -15,11 +15,17 @@ public:
         UNSIGNED_32 = 2,
         SIGNED_32 = 3,
         FLOAT_32 = 4,
+        STRING = 5,
     };
 
     static bool is32Bit(MbcDataType::Type type)
     {
         return cDataTypes[static_cast<int>(type)].b32Bit;
+    }
+
+    static bool isSupported(MbcDataType::Type type)
+    {
+        return type != Type::STRING;
     }
 
     static QString typeString(MbcDataType::Type type)
@@ -34,6 +40,8 @@ public:
             return "s32b";
         case Type::FLOAT_32:
             return "f32b";
+        case Type::STRING:
+            return "string";
         case Type::UNSIGNED_16:
         default:
             return "16b";
@@ -74,6 +82,12 @@ public:
         else if (strType == "float32")
         {
             return Type::FLOAT_32;
+        }
+        else if (strType.startsWith("string"))
+        {
+            /* String types (e.g. "string50") are not plottable, but are kept so they
+             * can be shown as invalid rather than failing the whole import. */
+            return Type::STRING;
         }
         else
         {

--- a/src/MbcInterface/mbcfileimporter.cpp
+++ b/src/MbcInterface/mbcfileimporter.cpp
@@ -245,7 +245,8 @@ bool MbcFileImporter::parseVarTag(const QDomElement& element, qint32 tabIdx)
             }
             else
             {
-                bRet = false;
+                /* Unknown/unsupported type: ignore this var and continue parsing */
+                return true;
             }
         }
 

--- a/src/MbcInterface/mbcfileimporter.cpp
+++ b/src/MbcInterface/mbcfileimporter.cpp
@@ -245,7 +245,9 @@ bool MbcFileImporter::parseVarTag(const QDomElement& element, qint32 tabIdx)
             }
             else
             {
-                /* Unknown/unsupported type: ignore this var and continue parsing */
+                /* Unknown/unsupported type: ignore this var but keep the auto-increment
+                 * address advancing so a following <reg>*</reg> still resolves. */
+                _nextRegisterAddr = static_cast<qint32>(modbusRegister.registerAddress()) + 1;
                 return true;
             }
         }
@@ -272,16 +274,23 @@ bool MbcFileImporter::parseVarTag(const QDomElement& element, qint32 tabIdx)
             /* Save register in list */
             _registerList.append(modbusRegister);
 
-            if (MbcDataType::is32Bit(modbusRegister.type()))
+            /* Advance the auto-increment address by the number of registers this
+             * variable occupies (2 bytes per register). */
+            qint32 registerSpan = 1;
+            if (modbusRegister.type() == MbcDataType::Type::STRING)
             {
-                /* Increment address with 2 */
-                _nextRegisterAddr = static_cast<qint32>(modbusRegister.registerAddress()) + 2;
+                const quint32 bytes = MbcDataType::stringByteLength(strType);
+                if (bytes >= 2)
+                {
+                    registerSpan = static_cast<qint32>((bytes + 1) / 2);
+                }
             }
-            else
+            else if (MbcDataType::is32Bit(modbusRegister.type()))
             {
-                /* Increment address with 1 */
-                _nextRegisterAddr = static_cast<qint32>(modbusRegister.registerAddress()) + 1;
+                registerSpan = 2;
             }
+
+            _nextRegisterAddr = static_cast<qint32>(modbusRegister.registerAddress()) + registerSpan;
         }
         else
         {

--- a/src/MbcInterface/mbcregistermodel.cpp
+++ b/src/MbcInterface/mbcregistermodel.cpp
@@ -117,7 +117,7 @@ QVariant MbcRegisterModel::data(const QModelIndex& index, int role) const
     if (!index.isValid())
         return QVariant();
 
-    auto const mbcRegister = _mbcRegisterList[index.row()];
+    const MbcRegister& mbcRegister = _mbcRegisterList[index.row()];
 
     if (role == Qt::ToolTipRole)
     {

--- a/src/MbcInterface/mbcregistermodel.cpp
+++ b/src/MbcInterface/mbcregistermodel.cpp
@@ -121,7 +121,11 @@ QVariant MbcRegisterModel::data(const QModelIndex& index, int role) const
 
     if (role == Qt::ToolTipRole)
     {
-        if (!mbcRegister.registerData.isReadable())
+        if (!MbcDataType::isSupported(mbcRegister.registerData.type()))
+        {
+            return "String data type is not supported";
+        }
+        else if (!mbcRegister.registerData.isReadable())
         {
             return "Not readable";
         }
@@ -283,7 +287,8 @@ void MbcRegisterModel::fill(QList<MbcRegisterData> mbcRegisterList, QStringList 
         // Get result before adding to list
         _mbcRegisterList.append({ mbcRegisterList[idx], false, false });
 
-        if (_mbcRegisterList.last().registerData.isReadable())
+        const MbcRegisterData& registerData = _mbcRegisterList.last().registerData;
+        if (registerData.isReadable() && MbcDataType::isSupported(registerData.type()))
         {
             _mbcRegisterList.last().bEnabled = true;
         }

--- a/src/MbcInterface/mbcregistermodel.cpp
+++ b/src/MbcInterface/mbcregistermodel.cpp
@@ -123,7 +123,7 @@ QVariant MbcRegisterModel::data(const QModelIndex& index, int role) const
     {
         if (!MbcDataType::isSupported(mbcRegister.registerData.type()))
         {
-            return "String data type is not supported";
+            return "Data type is not supported";
         }
         else if (!mbcRegister.registerData.isReadable())
         {

--- a/tests/MbcInterface/tst_mbcfileimporter.cpp
+++ b/tests/MbcInterface/tst_mbcfileimporter.cpp
@@ -172,6 +172,38 @@ void TestMbcFileImporter::importStringTypeMixed()
     QCOMPARE(regList[1].type(), MbcDataType::Type::STRING);
 }
 
+void TestMbcFileImporter::importAutoIncrementAfterSkippedType()
+{
+    // A skipped unknown-type var must still advance the auto-increment address so that
+    // a following <reg>*</reg> resolves instead of aborting the whole import.
+    QString content = "<?xml version=\"1.0\"?><modbuscontrol><tab><name>T1</name>"
+                      "<var><reg>40001</reg><text>Unknown</text><type>unknowntype</type><rw>r</rw></var>"
+                      "<var><reg>*</reg><text>Next</text><type>uint16</type><rw>r</rw></var>"
+                      "</tab></modbuscontrol>";
+    MbcFileImporter mbcFileImporter(&content);
+
+    QList<MbcRegisterData> regList = mbcFileImporter.registerList();
+    QCOMPARE(regList.size(), 1);
+    QCOMPARE(regList[0].name(), QString("Next"));
+    QCOMPARE(regList[0].registerAddress(), quint32(40002));
+}
+
+void TestMbcFileImporter::importAutoIncrementAfterString()
+{
+    // A string50 occupies 25 registers (50 bytes), so a following <reg>*</reg> must be
+    // placed after the whole string field, not one register later.
+    QString content = "<?xml version=\"1.0\"?><modbuscontrol><tab><name>T1</name>"
+                      "<var><reg>40100</reg><text>Str</text><type>string50</type><rw>r</rw></var>"
+                      "<var><reg>*</reg><text>Next</text><type>uint16</type><rw>r</rw></var>"
+                      "</tab></modbuscontrol>";
+    MbcFileImporter mbcFileImporter(&content);
+
+    QList<MbcRegisterData> regList = mbcFileImporter.registerList();
+    QCOMPARE(regList.size(), 2);
+    QCOMPARE(regList[0].type(), MbcDataType::Type::STRING);
+    QCOMPARE(regList[1].registerAddress(), quint32(40125));
+}
+
 void TestMbcFileImporter::importMixedReadWriteRegisters()
 {
     // Mix of readable and non-readable registers; all should be present

--- a/tests/MbcInterface/tst_mbcfileimporter.cpp
+++ b/tests/MbcInterface/tst_mbcfileimporter.cpp
@@ -130,13 +130,46 @@ void TestMbcFileImporter::importWriteOnlyRegister()
 
 void TestMbcFileImporter::importUnknownType()
 {
-    // An unrecognised type string causes the parser to emit an error and clear lists
+    // An unrecognised type is ignored: the var is skipped but other valid vars remain
     QString content = "<?xml version=\"1.0\"?><modbuscontrol><tab><name>T1</name>"
-                      "<var><reg>40001</reg><text>Reg1</text><type>unknowntype</type><rw>r</rw></var>"
+                      "<var><reg>40001</reg><text>Unknown</text><type>unknowntype</type><rw>r</rw></var>"
+                      "<var><reg>40002</reg><text>Valid</text><type>uint16</type><rw>r</rw></var>"
                       "</tab></modbuscontrol>";
     MbcFileImporter mbcFileImporter(&content);
 
-    QVERIFY(mbcFileImporter.registerList().isEmpty());
+    QList<MbcRegisterData> regList = mbcFileImporter.registerList();
+    QCOMPARE(regList.size(), 1);
+    QCOMPARE(regList[0].name(), QString("Valid"));
+    QCOMPARE(regList[0].registerAddress(), quint32(40002));
+}
+
+void TestMbcFileImporter::importStringType()
+{
+    // A string type is kept (not aborted) so it can be shown as an invalid register
+    QString content = "<?xml version=\"1.0\"?><modbuscontrol><tab><name>T1</name>"
+                      "<var><reg>40058</reg><text>File name</text><type>string50</type><rw>r</rw></var>"
+                      "</tab></modbuscontrol>";
+    MbcFileImporter mbcFileImporter(&content);
+
+    QList<MbcRegisterData> regList = mbcFileImporter.registerList();
+    QCOMPARE(regList.size(), 1);
+    QCOMPARE(regList[0].name(), QString("File name"));
+    QCOMPARE(regList[0].type(), MbcDataType::Type::STRING);
+}
+
+void TestMbcFileImporter::importStringTypeMixed()
+{
+    // A string var alongside a normal var: both are imported
+    QString content = "<?xml version=\"1.0\"?><modbuscontrol><tab><name>T1</name>"
+                      "<var><reg>40001</reg><text>Value</text><type>uint16</type><rw>r</rw></var>"
+                      "<var><reg>40058</reg><text>File name</text><type>string50</type><rw>r</rw></var>"
+                      "</tab></modbuscontrol>";
+    MbcFileImporter mbcFileImporter(&content);
+
+    QList<MbcRegisterData> regList = mbcFileImporter.registerList();
+    QCOMPARE(regList.size(), 2);
+    QCOMPARE(regList[0].type(), MbcDataType::Type::UNSIGNED_16);
+    QCOMPARE(regList[1].type(), MbcDataType::Type::STRING);
 }
 
 void TestMbcFileImporter::importMixedReadWriteRegisters()

--- a/tests/MbcInterface/tst_mbcfileimporter.h
+++ b/tests/MbcInterface/tst_mbcfileimporter.h
@@ -25,6 +25,8 @@ private slots:
     void importMissingRw();
     void importWriteOnlyRegister();
     void importUnknownType();
+    void importStringType();
+    void importStringTypeMixed();
     void importMixedReadWriteRegisters();
     void importEmptyVarTag();
 

--- a/tests/MbcInterface/tst_mbcfileimporter.h
+++ b/tests/MbcInterface/tst_mbcfileimporter.h
@@ -27,6 +27,8 @@ private slots:
     void importUnknownType();
     void importStringType();
     void importStringTypeMixed();
+    void importAutoIncrementAfterSkippedType();
+    void importAutoIncrementAfterString();
     void importMixedReadWriteRegisters();
     void importEmptyVarTag();
 

--- a/tests/MbcInterface/tst_mbcregistermodel.cpp
+++ b/tests/MbcInterface/tst_mbcregistermodel.cpp
@@ -494,6 +494,27 @@ void TestMbcRegisterModel::selectAllSkipNonReadable()
     QCOMPARE(pMbcRegisterModel->data(modelIdx.sibling(1, cColumnSelected), Qt::CheckStateRole), Qt::Unchecked);
 }
 
+void TestMbcRegisterModel::stringTypeRowDisabled()
+{
+    auto pMbcRegisterModel = std::make_unique<MbcRegisterModel>();
+    QList<MbcRegisterData> mbcRegisterList =
+      QList<MbcRegisterData>() << MbcRegisterData(40058, MbcDataType::Type::STRING, "FileName", 0, true, 0);
+    QStringList tabList = QStringList() << QString("Tab0");
+    pMbcRegisterModel->fill(mbcRegisterList, tabList);
+
+    QModelIndex modelIdx = pMbcRegisterModel->index(0, 0);
+
+    // A string-type register is disabled and carries an explanatory tooltip
+    QCOMPARE(pMbcRegisterModel->flags(modelIdx.sibling(0, cColumnAddress)), Qt::NoItemFlags);
+    QCOMPARE(pMbcRegisterModel->data(modelIdx.sibling(0, cColumnSelected), Qt::ToolTipRole).toString(),
+             "String data type is not supported");
+
+    // It cannot be checked
+    QModelIndex selectIdx = pMbcRegisterModel->index(0, cColumnSelected);
+    QCOMPARE(pMbcRegisterModel->setData(selectIdx, QVariant(Qt::Checked), Qt::CheckStateRole), false);
+    QCOMPARE(pMbcRegisterModel->selectedRegisterCount(), 0);
+}
+
 void TestMbcRegisterModel::setDataOnDisabledRowDoesNothing()
 {
     auto pMbcRegisterModel = std::make_unique<MbcRegisterModel>();

--- a/tests/MbcInterface/tst_mbcregistermodel.cpp
+++ b/tests/MbcInterface/tst_mbcregistermodel.cpp
@@ -507,7 +507,7 @@ void TestMbcRegisterModel::stringTypeRowDisabled()
     // A string-type register is disabled and carries an explanatory tooltip
     QCOMPARE(pMbcRegisterModel->flags(modelIdx.sibling(0, cColumnAddress)), Qt::NoItemFlags);
     QCOMPARE(pMbcRegisterModel->data(modelIdx.sibling(0, cColumnSelected), Qt::ToolTipRole).toString(),
-             "String data type is not supported");
+             "Data type is not supported");
 
     // It cannot be checked
     QModelIndex selectIdx = pMbcRegisterModel->index(0, cColumnSelected);

--- a/tests/MbcInterface/tst_mbcregistermodel.h
+++ b/tests/MbcInterface/tst_mbcregistermodel.h
@@ -30,6 +30,7 @@ private slots:
     void selectAllWhenMixedChecked();
     void selectAllSkipNonReadable();
 
+    void stringTypeRowDisabled();
     void setDataOnDisabledRowDoesNothing();
     void setDataInvalidIndexReturnsFalse();
     void headerDataCheckState();


### PR DESCRIPTION
## Summary

- Importing a `.mbc` file with a string-typed register (e.g. `<type>string50</type>`) previously aborted the entire import with "A tag is not present or value is not valid". String types are now recognized as a dedicated `MbcDataType::Type::STRING`, imported, and shown as a disabled/non-selectable row with the tooltip "String data type is not supported" (ModbusScope has no way to plot string data).
- Any other unrecognized `<type>` value now causes just that single `<var>` to be skipped, instead of aborting the whole file import.
- Fixed the `<reg>*</reg>` auto-increment address bookkeeping so it still advances correctly past a skipped unknown-type var, and advances by the correct register span for string types (e.g. `string50` occupies 25 registers, not 1).

## Test plan

- [x] Added `tst_mbcfileimporter` cases: `importStringType`, `importStringTypeMixed`, `importAutoIncrementAfterSkippedType`, `importAutoIncrementAfterString`, and updated `importUnknownType` to assert skip-and-continue behavior.
- [x] Added `tst_mbcregistermodel` case: `stringTypeRowDisabled` (row disabled, correct tooltip, not selectable).
- [x] CI build/test/quality (not runnable in this cloud container — verify via CI on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FR1Y386qbP3o36MycvJmzm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for string-based register types (e.g., `string50`), including parsing their byte length and representing them as a distinct data type.
  * Auto-increment now correctly reserves the full register span for string fields.

* **Bug Fixes**
  * Unknown `<var>` register types are now skipped without aborting the rest of the import.
  * Unsupported data types are now disabled in the register model and show an explanatory tooltip.

* **Tests**
  * Expanded automated coverage for string imports, mixed-type cases, auto-increment after skipped/strings, and disabled string rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->