### PR TITLE
Multi adapter fixes

### DIFF
--- a/src/ProtocolAdapter/adapterclient.cpp
+++ b/src/ProtocolAdapter/adapterclient.cpp
@@ -6,8 +6,22 @@
 
 #include <memory>
 
-AdapterClient::AdapterClient(std::unique_ptr<AdapterProcess> pProcess, QObject* parent, int handshakeTimeoutMs)
-    : QObject(parent), _pProcess(std::move(pProcess)), _handshakeTimeoutMs(handshakeTimeoutMs)
+/*!
+ * \brief Construct an AdapterClient driving \a pProcess.
+ * \param pProcess          Transport for the adapter subprocess; ownership is taken.
+ * \param adapterId         Identifier of the adapter this client talks to (e.g. "modbus", "iec104"),
+ *                          used only to tag diagnostic log lines. May be empty.
+ * \param parent            Optional QObject parent.
+ * \param handshakeTimeoutMs Timeout in milliseconds for adapter handshake responses.
+ */
+AdapterClient::AdapterClient(std::unique_ptr<AdapterProcess> pProcess,
+                             QString adapterId,
+                             QObject* parent,
+                             int handshakeTimeoutMs)
+    : QObject(parent),
+      _adapterId(std::move(adapterId)),
+      _pProcess(std::move(pProcess)),
+      _handshakeTimeoutMs(handshakeTimeoutMs)
 {
     Q_ASSERT(_pProcess);
 
@@ -37,7 +51,7 @@ void AdapterClient::prepareAdapter(const QString& adapterPath)
 {
     if (_state != State::IDLE)
     {
-        qCWarning(scopeComm) << "AdapterClient: prepareAdapter called in non-idle state";
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "prepareAdapter called in non-idle state";
         return;
     }
 
@@ -46,7 +60,7 @@ void AdapterClient::prepareAdapter(const QString& adapterPath)
         return;
     }
 
-    qCInfo(scopeComm) << "AdapterClient: process started, sending initialize";
+    qCInfo(scopeComm) << "AdapterClient:" << _adapterId << "process started, sending initialize";
     _state = State::INITIALIZING;
     _handshakeTimer.start(_handshakeTimeoutMs);
     _pProcess->sendRequest("adapter.initialize", QJsonObject());
@@ -56,7 +70,8 @@ void AdapterClient::provideConfig(QJsonObject config, QStringList registerExpres
 {
     if (_state != State::AWAITING_CONFIG)
     {
-        qCWarning(scopeComm) << "AdapterClient: provideConfig called in unexpected state" << static_cast<int>(_state);
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "provideConfig called in unexpected state"
+                             << static_cast<int>(_state);
         return;
     }
 
@@ -74,7 +89,7 @@ void AdapterClient::requestReadData()
 {
     if (_state != State::ACTIVE)
     {
-        qCWarning(scopeComm) << "AdapterClient: requestReadData called in non-active state";
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "requestReadData called in non-active state";
         return;
     }
 
@@ -85,7 +100,7 @@ void AdapterClient::requestStatus()
 {
     if (_state != State::ACTIVE)
     {
-        qCWarning(scopeComm) << "AdapterClient: requestStatus called in non-active state";
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "requestStatus called in non-active state";
         return;
     }
 
@@ -99,7 +114,7 @@ void AdapterClient::requestDataPointSchema()
 {
     if (_state != State::AWAITING_CONFIG)
     {
-        qCWarning(scopeComm) << "AdapterClient: requestDataPointSchema called in unexpected state"
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "requestDataPointSchema called in unexpected state"
                              << static_cast<int>(_state);
         return;
     }
@@ -115,7 +130,7 @@ void AdapterClient::describeDataPoint(const QString& expression)
 {
     if (_state != State::AWAITING_CONFIG && _state != State::ACTIVE)
     {
-        qCWarning(scopeComm) << "AdapterClient: describeDataPoint called in unexpected state"
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "describeDataPoint called in unexpected state"
                              << static_cast<int>(_state);
         return;
     }
@@ -133,7 +148,7 @@ void AdapterClient::validateDataPoint(const QString& expression)
 {
     if (_state != State::AWAITING_CONFIG && _state != State::ACTIVE)
     {
-        qCWarning(scopeComm) << "AdapterClient: validateDataPoint called in unexpected state"
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "validateDataPoint called in unexpected state"
                              << static_cast<int>(_state);
         return;
     }
@@ -153,7 +168,8 @@ void AdapterClient::buildExpression(const QJsonObject& addressFields, const QStr
 {
     if (_state != State::AWAITING_CONFIG && _state != State::ACTIVE)
     {
-        qCWarning(scopeComm) << "AdapterClient: buildExpression called in unexpected state" << static_cast<int>(_state);
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "buildExpression called in unexpected state"
+                             << static_cast<int>(_state);
         return;
     }
 
@@ -178,7 +194,7 @@ void AdapterClient::requestExpressionHelp()
 {
     if (_state != State::AWAITING_CONFIG && _state != State::ACTIVE)
     {
-        qCWarning(scopeComm) << "AdapterClient: requestExpressionHelp called in unexpected state"
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "requestExpressionHelp called in unexpected state"
                              << static_cast<int>(_state);
         return;
     }
@@ -220,7 +236,7 @@ void AdapterClient::onResponseReceived(int id, const QString& method, const QJso
     }
     else
     {
-        qCWarning(scopeComm) << "AdapterClient: unexpected non-object result for" << method;
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "unexpected non-object result for" << method;
         _handshakeTimer.stop();
         /* Set IDLE before stop() so onProcessFinished's IDLE guard suppresses any
            duplicate sessionError emission when the process exits asynchronously. */
@@ -235,7 +251,7 @@ void AdapterClient::onErrorReceived(int id, const QString& method, const QJsonOb
 {
     _handshakeTimer.stop();
     QString errorMsg = error.value("message").toString();
-    qCWarning(scopeComm) << "AdapterClient: error for" << method << ":" << errorMsg;
+    qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "error for" << method << ":" << errorMsg;
 
     /* For auxiliary requests, a JSON-RPC error is a non-fatal result rather
        than a session-level failure. Translate to the corresponding result signal or swallow. */
@@ -323,7 +339,8 @@ void AdapterClient::onProcessFinished()
 
 void AdapterClient::onHandshakeTimeout()
 {
-    qCWarning(scopeComm) << "AdapterClient: handshake timed out in state" << static_cast<int>(_state);
+    qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "handshake timed out in state"
+                         << static_cast<int>(_state);
     bool wasUserStop = (_state == State::STOPPING || _state == State::STOPPING_SESSION);
     _pendingAuxRequests.clear();
     _state = State::IDLE;
@@ -347,7 +364,7 @@ void AdapterClient::onNotificationReceived(QString method, QJsonValue params)
 
     if (!params.isObject())
     {
-        qCWarning(scopeComm) << "AdapterClient: adapter.diagnostic params is not an object";
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "adapter.diagnostic params is not an object";
         return;
     }
 
@@ -364,7 +381,7 @@ bool AdapterClient::consumeAuxResponse(const QString& method, int id)
 {
     if (_pendingAuxRequests.value(method, -1) != id)
     {
-        qCWarning(scopeComm) << "AdapterClient: ignoring stale response for" << method;
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "ignoring stale response for" << method;
         return false;
     }
     _pendingAuxRequests.remove(method);
@@ -375,13 +392,13 @@ void AdapterClient::handleLifecycleResponse(int id, const QString& method, const
 {
     if (method == "adapter.initialize" && _state == State::INITIALIZING)
     {
-        qCInfo(scopeComm) << "AdapterClient: initialized, sending describe";
+        qCInfo(scopeComm) << "AdapterClient:" << _adapterId << "initialized, sending describe";
         _state = State::DESCRIBING;
         _pProcess->sendRequest("adapter.describe", QJsonObject());
     }
     else if (method == "adapter.describe" && _state == State::DESCRIBING)
     {
-        qCInfo(scopeComm) << "AdapterClient: described, awaiting config";
+        qCInfo(scopeComm) << "AdapterClient:" << _adapterId << "described, awaiting config";
         _handshakeTimer.stop();
         _state = State::AWAITING_CONFIG;
         emit describeResult(result);
@@ -389,7 +406,7 @@ void AdapterClient::handleLifecycleResponse(int id, const QString& method, const
     }
     else if (method == "adapter.configure" && _state == State::CONFIGURING)
     {
-        qCInfo(scopeComm) << "AdapterClient: configured, sending start";
+        qCInfo(scopeComm) << "AdapterClient:" << _adapterId << "configured, sending start";
         _state = State::STARTING;
         QJsonObject params;
         params["dataPoints"] = QJsonArray::fromStringList(_pendingExpressions);
@@ -397,7 +414,7 @@ void AdapterClient::handleLifecycleResponse(int id, const QString& method, const
     }
     else if (method == "adapter.start" && _state == State::STARTING)
     {
-        qCInfo(scopeComm) << "AdapterClient: started";
+        qCInfo(scopeComm) << "AdapterClient:" << _adapterId << "started";
         _handshakeTimer.stop();
         _state = State::ACTIVE;
         emit sessionStarted();
@@ -426,7 +443,7 @@ void AdapterClient::handleLifecycleResponse(int id, const QString& method, const
     }
     else if (method == "adapter.stop" && _state == State::STOPPING_SESSION)
     {
-        qCInfo(scopeComm) << "AdapterClient: session stopped, adapter kept alive, awaiting config";
+        qCInfo(scopeComm) << "AdapterClient:" << _adapterId << "session stopped, adapter kept alive, awaiting config";
         _handshakeTimer.stop();
         _state = State::AWAITING_CONFIG;
         emit sessionStopped();
@@ -474,7 +491,7 @@ void AdapterClient::handleLifecycleResponse(int id, const QString& method, const
     }
     else
     {
-        qCWarning(scopeComm) << "AdapterClient: unexpected response for" << method << "in state"
+        qCWarning(scopeComm) << "AdapterClient:" << _adapterId << "unexpected response for" << method << "in state"
                              << static_cast<int>(_state);
     }
 }

--- a/src/ProtocolAdapter/adapterclient.cpp
+++ b/src/ProtocolAdapter/adapterclient.cpp
@@ -47,6 +47,11 @@ bool AdapterClient::isIdle() const
     return _state == State::IDLE;
 }
 
+bool AdapterClient::isActive() const
+{
+    return _state == State::ACTIVE;
+}
+
 void AdapterClient::prepareAdapter(const QString& adapterPath)
 {
     if (_state != State::IDLE)

--- a/src/ProtocolAdapter/adapterclient.h
+++ b/src/ProtocolAdapter/adapterclient.h
@@ -31,6 +31,7 @@ class AdapterClient : public QObject
 
 public:
     explicit AdapterClient(std::unique_ptr<AdapterProcess> pProcess,
+                           QString adapterId = QString(),
                            QObject* parent = nullptr,
                            int handshakeTimeoutMs = 10000);
     ~AdapterClient();
@@ -262,6 +263,7 @@ private:
 
     State _state{ State::IDLE };
 
+    QString _adapterId;
     std::unique_ptr<AdapterProcess> _pProcess;
     QTimer _handshakeTimer;
     int _handshakeTimeoutMs;

--- a/src/ProtocolAdapter/adapterclient.h
+++ b/src/ProtocolAdapter/adapterclient.h
@@ -100,6 +100,11 @@ public:
     bool isIdle() const;
 
     /*!
+     * \brief Returns true when the adapter has an established session (ACTIVE state).
+     */
+    bool isActive() const;
+
+    /*!
      * \brief Send an adapter.dataPointSchema request to discover the data point UI schema.
      *
      * Must only be called after describeResult() has been emitted (i.e., in the

--- a/src/ProtocolAdapter/adapterhub.cpp
+++ b/src/ProtocolAdapter/adapterhub.cpp
@@ -82,22 +82,46 @@ void AdapterHub::startSession(const QString& adapterId, const QStringList& expre
     }
 }
 
-/*! \brief Send adapter.stop to all active adapter managers. */
+/*! \brief Send adapter.stop to every adapter manager with a session in progress or established.
+ *
+ * A manager that never started a session (still AWAITING_CONFIG) or has no process running
+ * (IDLE) is left untouched. A manager mid-handshake (CONFIGURING/STARTING) is force-stopped but
+ * not waited on, since only a graceful stop from ACTIVE emits adapterReady(). A force-stopped
+ * mid-handshake manager is also purged from _pendingStartAdapters here, since that force-stop
+ * only emits sessionStopped() - never the sessionStarted()/sessionError() that would otherwise
+ * clear it.
+ */
 void AdapterHub::stopSession()
 {
     for (auto it = _adapterManagers.constBegin(); it != _adapterManagers.constEnd(); ++it)
     {
-        _pendingReadyAdapters.insert(it.key());
-        it.value()->stopSession();
+        AdapterManager* mgr = it.value();
+        if (mgr->isAdapterIdle() || mgr->isAdapterReady())
+        {
+            continue;
+        }
+
+        if (mgr->isAdapterActive())
+        {
+            _pendingReadyAdapters.insert(it.key());
+        }
+        else
+        {
+            _pendingStartAdapters.remove(it.key());
+        }
+        mgr->stopSession();
     }
 }
 
-/*! \brief Send adapter.readData to all adapter managers. */
+/*! \brief Send adapter.readData to all adapter managers with an established session. */
 void AdapterHub::requestReadData()
 {
     for (auto it = _adapterManagers.constBegin(); it != _adapterManagers.constEnd(); ++it)
     {
-        it.value()->requestReadData();
+        if (it.value()->isAdapterActive())
+        {
+            it.value()->requestReadData();
+        }
     }
 }
 

--- a/src/ProtocolAdapter/adaptermanager.cpp
+++ b/src/ProtocolAdapter/adaptermanager.cpp
@@ -73,6 +73,12 @@ bool AdapterManager::isAdapterIdle() const
     return _pAdapterClient->isIdle();
 }
 
+/*! \brief Returns true when the adapter has an established session (ACTIVE state). */
+bool AdapterManager::isAdapterActive() const
+{
+    return _pAdapterClient->isActive();
+}
+
 /*! \brief Send an adapter.expressionHelp request to retrieve expression syntax help text. */
 void AdapterManager::requestExpressionHelp()
 {

--- a/src/ProtocolAdapter/adaptermanager.cpp
+++ b/src/ProtocolAdapter/adaptermanager.cpp
@@ -14,7 +14,7 @@ AdapterManager::AdapterManager(const QString& adapterId,
                                QObject* parent)
     : QObject(parent), _adapterId(adapterId), _adapterBinaryPath(adapterBinaryPath), _pSettingsModel(pSettingsModel)
 {
-    _pAdapterClient = new AdapterClient(std::make_unique<AdapterProcess>(), this);
+    _pAdapterClient = new AdapterClient(std::make_unique<AdapterProcess>(), _adapterId, this);
 
     connect(_pAdapterClient, &AdapterClient::sessionStarted, this, &AdapterManager::sessionStarted);
     connect(_pAdapterClient, &AdapterClient::readDataResult, this, &AdapterManager::readDataResult);

--- a/src/ProtocolAdapter/adaptermanager.h
+++ b/src/ProtocolAdapter/adaptermanager.h
@@ -66,6 +66,11 @@ public:
     virtual bool isAdapterIdle() const;
 
     /*!
+     * \brief Returns true when the adapter has an established session (ACTIVE state).
+     */
+    virtual bool isAdapterActive() const;
+
+    /*!
      * \brief Send an adapter.readData request to the active adapter.
      */
     virtual void requestReadData();

--- a/tests/ProtocolAdapter/tst_adapterclient.cpp
+++ b/tests/ProtocolAdapter/tst_adapterclient.cpp
@@ -1222,7 +1222,7 @@ void TestAdapterClient::canProvideConfigAfterStop()
     QCOMPARE(spyStarted.count(), 2);
 }
 
-void TestAdapterClient::isReadyAndIsIdleAccessors()
+void TestAdapterClient::isReadyIsIdleAndIsActiveAccessors()
 {
     auto mockOwned = std::make_unique<MockAdapterProcess>();
     auto* mock = mockOwned.get();
@@ -1231,21 +1231,25 @@ void TestAdapterClient::isReadyAndIsIdleAccessors()
     /* Initially IDLE */
     QVERIFY(client.isIdle());
     QVERIFY(!client.isReady());
+    QVERIFY(!client.isActive());
 
     client.prepareAdapter(QStringLiteral("./dummy"));
     /* INITIALIZING */
     QVERIFY(!client.isIdle());
     QVERIFY(!client.isReady());
+    QVERIFY(!client.isActive());
 
     mock->injectResponse(1, "adapter.initialize", QJsonObject{ { "status", "ok" } });
     /* DESCRIBING */
     QVERIFY(!client.isIdle());
     QVERIFY(!client.isReady());
+    QVERIFY(!client.isActive());
 
     mock->injectResponse(2, "adapter.describe", describeResult());
     /* AWAITING_CONFIG */
     QVERIFY(!client.isIdle());
     QVERIFY(client.isReady());
+    QVERIFY(!client.isActive());
 
     client.provideConfig(QJsonObject(), QStringList());
     mock->injectResponse(3, "adapter.configure", QJsonObject{ { "status", "ok" } });
@@ -1253,6 +1257,7 @@ void TestAdapterClient::isReadyAndIsIdleAccessors()
     /* ACTIVE */
     QVERIFY(!client.isIdle());
     QVERIFY(!client.isReady());
+    QVERIFY(client.isActive());
 }
 
 QTEST_GUILESS_MAIN(TestAdapterClient)

--- a/tests/ProtocolAdapter/tst_adapterclient.cpp
+++ b/tests/ProtocolAdapter/tst_adapterclient.cpp
@@ -573,7 +573,7 @@ void TestAdapterClient::adapterStopNoAckTimesOutToSessionStopped()
 {
     auto mockOwned = std::make_unique<MockAdapterProcess>();
     auto* mock = mockOwned.get();
-    AdapterClient client(std::move(mockOwned), nullptr, 250 /* ms */);
+    AdapterClient client(std::move(mockOwned), QString(), nullptr, 250 /* ms */);
 
     QSignalSpy spyStopped(&client, &AdapterClient::sessionStopped);
     QSignalSpy spyError(&client, &AdapterClient::sessionError);

--- a/tests/ProtocolAdapter/tst_adapterclient.h
+++ b/tests/ProtocolAdapter/tst_adapterclient.h
@@ -39,7 +39,7 @@ private slots:
     void adapterReadyEmittedAfterDescribe();
     void adapterReadyEmittedAfterStop();
     void canProvideConfigAfterStop();
-    void isReadyAndIsIdleAccessors();
+    void isReadyIsIdleAndIsActiveAccessors();
 
     void requestDataPointSchemaEmitsSignal();
     void requestDataPointSchemaInWrongStateIgnored();

--- a/tests/ProtocolAdapter/tst_adapterhub.cpp
+++ b/tests/ProtocolAdapter/tst_adapterhub.cpp
@@ -1,9 +1,68 @@
 #include "tst_adapterhub.h"
 
 #include "ProtocolAdapter/adapterhub.h"
+#include "ProtocolAdapter/adaptermanager.h"
 
 #include <QSignalSpy>
 #include <QTest>
+
+namespace {
+
+/*! \brief Minimal AdapterManager double for testing AdapterHub's per-manager iteration logic. */
+class FakeAdapterManager : public AdapterManager
+{
+public:
+    /*! \brief Mirrors the AdapterClient states AdapterHub distinguishes between. */
+    enum class FakeState
+    {
+        Idle,
+        AwaitingConfig, /*!< Discovered but never started a session. */
+        MidHandshake,   /*!< CONFIGURING/STARTING: session requested, not yet established. */
+        Active
+    };
+
+    FakeAdapterManager(const QString& id, FakeState state, QObject* parent)
+        : AdapterManager(id, QString(), nullptr, parent), _state(state)
+    {
+    }
+
+    bool isAdapterIdle() const override
+    {
+        return _state == FakeState::Idle;
+    }
+    bool isAdapterReady() const override
+    {
+        return _state == FakeState::AwaitingConfig;
+    }
+    bool isAdapterActive() const override
+    {
+        return _state == FakeState::Active;
+    }
+    void requestReadData() override
+    {
+        _readDataCalls++;
+    }
+    void stopSession() override
+    {
+        _stopSessionCalls++;
+    }
+
+    int readDataCalls() const
+    {
+        return _readDataCalls;
+    }
+    int stopSessionCalls() const
+    {
+        return _stopSessionCalls;
+    }
+
+private:
+    FakeState _state;
+    int _readDataCalls = 0;
+    int _stopSessionCalls = 0;
+};
+
+} // namespace
 
 /*!
  * \brief A single pending adapter that fails to start must only report sessionError.
@@ -64,6 +123,113 @@ void TestAdapterHub::allAdaptersSucceedEmitsSessionStartedOnce()
     QCOMPARE(startedSpy.count(), 0);
 
     hub.onManagerSessionStarted(QStringLiteral("sim"));
+    QCOMPARE(startedSpy.count(), 1);
+}
+
+/*!
+ * \brief requestReadData() must only reach adapters that have an established session -
+ * an adapter with no configured registers is discovered and initialized but never
+ * started, and must not be polled (regression test for spurious "non-active state"
+ * warnings being logged every poll cycle).
+ */
+void TestAdapterHub::requestReadDataSkipsInactiveAdapters()
+{
+    AdapterHub hub;
+    auto* pActive = new FakeAdapterManager(QStringLiteral("iec104"), FakeAdapterManager::FakeState::Active, &hub);
+    auto* pInactive =
+      new FakeAdapterManager(QStringLiteral("modbus"), FakeAdapterManager::FakeState::AwaitingConfig, &hub);
+    hub._adapterManagers.insert(QStringLiteral("iec104"), pActive);
+    hub._adapterManagers.insert(QStringLiteral("modbus"), pInactive);
+
+    hub.requestReadData();
+
+    QCOMPARE(pActive->readDataCalls(), 1);
+    QCOMPARE(pInactive->readDataCalls(), 0);
+}
+
+/*!
+ * \brief stopSession() must only reach and wait on adapters that have an established
+ * session - an adapter that was discovered but never started must be left alone (it is
+ * already in a state ready for the next session). Regression test: previously every
+ * manager's id was added to _pendingReadyAdapters and stopSession() force-killed the
+ * never-started adapter's process, but that path never emits adapterReady(), so
+ * _pendingReadyAdapters could never empty again and adapterReady() would never re-fire.
+ */
+void TestAdapterHub::stopSessionOnlyWaitsOnActiveAdapters()
+{
+    AdapterHub hub;
+    auto* pActive = new FakeAdapterManager(QStringLiteral("iec104"), FakeAdapterManager::FakeState::Active, &hub);
+    auto* pInactive =
+      new FakeAdapterManager(QStringLiteral("modbus"), FakeAdapterManager::FakeState::AwaitingConfig, &hub);
+    hub._adapterManagers.insert(QStringLiteral("iec104"), pActive);
+    hub._adapterManagers.insert(QStringLiteral("modbus"), pInactive);
+
+    QSignalSpy readySpy(&hub, &AdapterHub::adapterReady);
+
+    hub.stopSession();
+
+    QCOMPARE(pActive->stopSessionCalls(), 1);
+    QCOMPARE(pInactive->stopSessionCalls(), 0);
+
+    /* Only the active adapter's graceful stop leads to adapterReady(). If the inactive
+       adapter had also been added to _pendingReadyAdapters, this would never fire. */
+    hub.onManagerAdapterReady(QStringLiteral("iec104"));
+    QCOMPARE(readySpy.count(), 1);
+}
+
+/*!
+ * \brief stopSession() must force-stop an adapter that is mid-handshake (session requested via
+ * startSession() but not yet ACTIVE) without waiting on it, since a force-killed mid-handshake
+ * adapter only emits sessionStopped(), never adapterReady(). Regression test: previously such an
+ * adapter was skipped entirely (left running to silently become an untracked, zombie session), or
+ * - before the first stopSession() fix - was added to _pendingReadyAdapters and deadlocked
+ * adapterReady() just like the never-started case.
+ */
+void TestAdapterHub::stopSessionForceStopsMidHandshakeAdaptersWithoutWaiting()
+{
+    AdapterHub hub;
+    auto* pActive = new FakeAdapterManager(QStringLiteral("iec104"), FakeAdapterManager::FakeState::Active, &hub);
+    auto* pMidHandshake =
+      new FakeAdapterManager(QStringLiteral("modbus"), FakeAdapterManager::FakeState::MidHandshake, &hub);
+    hub._adapterManagers.insert(QStringLiteral("iec104"), pActive);
+    hub._adapterManagers.insert(QStringLiteral("modbus"), pMidHandshake);
+
+    QSignalSpy readySpy(&hub, &AdapterHub::adapterReady);
+
+    hub.stopSession();
+
+    /* Force-stopped, unlike the never-started case, to avoid leaving an untracked session. */
+    QCOMPARE(pMidHandshake->stopSessionCalls(), 1);
+
+    /* Not waited on: if it had been added to _pendingReadyAdapters, this would never fire,
+       since a force-stopped mid-handshake adapter never emits adapterReady(). */
+    hub.onManagerAdapterReady(QStringLiteral("iec104"));
+    QCOMPARE(readySpy.count(), 1);
+}
+
+/*!
+ * \brief stopSession() must purge a force-stopped mid-handshake adapter from
+ * _pendingStartAdapters. Regression test: that adapter's force-stop only emits
+ * sessionStopped(), never sessionStarted()/sessionError(), so nothing else would ever
+ * clear its id - leaving _pendingStartAdapters unable to empty again and sessionStarted()
+ * unable to ever re-fire, even once every other adapter starts successfully.
+ */
+void TestAdapterHub::stopSessionPurgesPendingStartForForceStoppedAdapters()
+{
+    AdapterHub hub;
+    auto* pActive = new FakeAdapterManager(QStringLiteral("iec104"), FakeAdapterManager::FakeState::Active, &hub);
+    auto* pMidHandshake =
+      new FakeAdapterManager(QStringLiteral("modbus"), FakeAdapterManager::FakeState::MidHandshake, &hub);
+    hub._adapterManagers.insert(QStringLiteral("iec104"), pActive);
+    hub._adapterManagers.insert(QStringLiteral("modbus"), pMidHandshake);
+    hub._pendingStartAdapters.insert(QStringLiteral("modbus"));
+
+    QSignalSpy startedSpy(&hub, &AdapterHub::sessionStarted);
+
+    hub.stopSession();
+
+    /* If "modbus" were still pending, this alone would not be enough to empty the set. */
+    hub.onManagerSessionStarted(QStringLiteral("iec104"));
     QCOMPARE(startedSpy.count(), 1);
 }
 

--- a/tests/ProtocolAdapter/tst_adapterhub.h
+++ b/tests/ProtocolAdapter/tst_adapterhub.h
@@ -10,6 +10,10 @@ private slots:
     void errorOnSingleAdapterEmitsErrorOnly();
     void errorOnLastPendingAdapterDoesNotEmitSessionStarted();
     void allAdaptersSucceedEmitsSessionStartedOnce();
+    void requestReadDataSkipsInactiveAdapters();
+    void stopSessionOnlyWaitsOnActiveAdapters();
+    void stopSessionForceStopsMidHandshakeAdaptersWithoutWaiting();
+    void stopSessionPurgesPendingStartForForceStoppedAdapters();
 };
 
 #endif // TST_ADAPTERHUB_H

--- a/tests/integration/tst_dummyadapter.cpp
+++ b/tests/integration/tst_dummyadapter.cpp
@@ -85,7 +85,7 @@ void TestDummyAdapter::initTestCase()
  */
 void TestDummyAdapter::init()
 {
-    _pClient = new AdapterClient(std::make_unique<AdapterProcess>(), this);
+    _pClient = new AdapterClient(std::make_unique<AdapterProcess>(), QString(), this);
 }
 
 /*!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added adapter activity status checks for clearer session-state visibility.
  - Adapter-specific identifiers are now included in diagnostic messages.

- **Bug Fixes**
  - Data requests are sent only to active adapters.
  - Session stopping now handles active and mid-handshake adapters appropriately, avoiding unnecessary waits and preserving subsequent starts.

- **Tests**
  - Added coverage for activity states, selective data requests, and session-stop behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->