### PR TITLE
Resize Add Register popup when switching adapters

### DIFF
--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -8,8 +8,10 @@
 #include "models/device.h"
 #include "models/settingsmodel.h"
 
+#include <QCoreApplication>
 #include <QJsonArray>
 #include <QMenu>
+#include <QResizeEvent>
 #include <QVBoxLayout>
 
 /*!
@@ -142,16 +144,25 @@ void AddRegisterWidget::rebuildAddressForm()
  * \brief Resizes the enclosing popup menu to fit this widget's current content.
  *
  * When hosted as a QWidgetAction's default widget inside a QToolButton's popup menu (as
- * RegisterDialog does for btnAdd), QMenu computes and caches its size when shown and does not
- * observe later size changes of an already-embedded widget. Without this, switching adapters
- * while the popup is open leaves it clipped to whichever adapter was shown first.
+ * RegisterDialog does for btnAdd), QMenu caches its action layout and only recomputes it for
+ * specific events (its action list changing, being shown, or being resized) - it has no way to
+ * know an already-embedded widget's own content changed. Without this, switching adapters while
+ * the popup is open leaves it clipped to whichever adapter was shown first. A synthetic resize
+ * event forces QMenu to mark its cached layout dirty and recompute it, so the sizeHint() below
+ * reflects the rebuilt form instead of stale, cached action rects.
  */
 void AddRegisterWidget::resizeContainingMenu()
 {
-    if (auto* menu = qobject_cast<QMenu*>(window()))
+    auto* menu = qobject_cast<QMenu*>(window());
+    if (menu == nullptr)
     {
-        menu->resize(menu->sizeHint());
+        return;
     }
+
+    QResizeEvent resizeEvent(menu->size(), menu->size());
+    QCoreApplication::sendEvent(menu, &resizeEvent);
+
+    menu->resize(menu->sizeHint());
 }
 
 /*!

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -9,6 +9,7 @@
 #include "models/settingsmodel.h"
 
 #include <QJsonArray>
+#include <QMenu>
 #include <QVBoxLayout>
 
 /*!
@@ -124,6 +125,8 @@ void AddRegisterWidget::applyAdapter(const QString& adapterId)
     rebuildAddressForm();
 
     _pUi->btnAdd->setEnabled(isAdapterUsable(adapterId));
+
+    resizeContainingMenu();
 }
 
 /*!
@@ -132,6 +135,22 @@ void AddRegisterWidget::applyAdapter(const QString& adapterId)
 void AddRegisterWidget::rebuildAddressForm()
 {
     _pAddressForm->setSchema(_addressSchema, _dataPointDefaults);
+}
+
+/*!
+ * \brief Resizes the enclosing popup menu to fit this widget's current content.
+ *
+ * When hosted as a QWidgetAction's default widget inside a QToolButton's popup menu (as
+ * RegisterDialog does for btnAdd), QMenu computes and caches its size when shown and does not
+ * observe later size changes of an already-embedded widget. Without this, switching adapters
+ * while the popup is open leaves it clipped to whichever adapter was shown first.
+ */
+void AddRegisterWidget::resizeContainingMenu()
+{
+    if (auto* menu = qobject_cast<QMenu*>(window()))
+    {
+        menu->resize(menu->sizeHint());
+    }
 }
 
 /*!

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -107,7 +107,8 @@ QJsonObject AddRegisterWidget::buildSchema(const QString& adapterId) const
  * \brief Switch the widget to the given adapter's register schema.
  *
  * Rebuilds the address form from the adapter's data point schema and updates
- * the add button state based on manager and device availability.
+ * the add button state based on manager and device availability. Also resizes
+ * the enclosing popup menu, if any, to fit the rebuilt form.
  * \param adapterId Identifier of the adapter to use.
  */
 void AddRegisterWidget::applyAdapter(const QString& adapterId)
@@ -220,6 +221,7 @@ void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
 
     resetFields();
     rebuildAddressForm();
+    resizeContainingMenu();
 }
 
 void AddRegisterWidget::resetFields()

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -40,6 +40,7 @@ private:
     void collectPendingGraphData();
     void applyAdapter(const QString& adapterId);
     void rebuildAddressForm();
+    void resizeContainingMenu();
     bool isAdapterUsable(const QString& adapterId) const;
     QString selectedAdapterId() const;
     QJsonObject buildSchema(const QString& adapterId) const;

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -289,34 +289,30 @@ void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
 {
     addSimAdapter();
 
+    /* QWidgetAction::setDefaultWidget() takes ownership of the widget: its destructor
+     * unconditionally deletes it. Hand it off and clear the fixture pointer up front - before
+     * the QVERIFY below, which returns early on failure - so cleanup()'s `delete _pRegWidget`
+     * can never race with the action's destructor deleting the same object. */
+    AddRegisterWidget* pWidget = _pRegWidget;
+    _pRegWidget = nullptr;
+
     QMenu menu;
     auto* action = new QWidgetAction(&menu);
-    action->setDefaultWidget(_pRegWidget);
+    action->setDefaultWidget(pWidget);
+    /* Reparents pWidget into `menu` synchronously (QMenu::actionEvent). */
     menu.addAction(action);
 
-    /* Showing forces the menu to adopt the widget and size itself, as happens
-     * the first time RegisterDialog's btnAdd popup is opened. */
+    /* Showing lays out the menu for the first time, sizing it to fit the modbus schema (4 fields). */
     menu.show();
     const int heightWithFourFields = menu.height();
 
     /* Switch, while the popup is open, from modbus (4 fields) to sim (1 field) */
-    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
-
-    QVERIFY(menu.height() < heightWithFourFields);
+    pWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    const int heightWithOneField = menu.height();
 
     menu.hide();
 
-    /* QWidgetAction::setDefaultWidget() reparents the widget into whichever container
-     * displays it, but ~QWidgetAction() unconditionally deletes the default widget too.
-     * If the widget were still a child of `menu` when `menu` is destroyed below, both
-     * menu's own child cleanup and the action's destructor would try to delete it,
-     * causing a double free. releaseWidget() detaches it (parent -> nullptr) first, so
-     * only the action's destructor deletes it. */
-    action->releaseWidget(_pRegWidget);
-
-    /* Ownership remains with `action` (destroyed below with `menu`); avoid a double
-     * delete in cleanup(). */
-    _pRegWidget = nullptr;
+    QVERIFY(heightWithOneField < heightWithFourFields);
 }
 
 void TestAddRegisterWidget::buildExpressionRoutedToSelectedAdapter()

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -8,8 +8,10 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QMenu>
 #include <QSignalSpy>
 #include <QTest>
+#include <QWidgetAction>
 
 QJsonObject TestAddRegisterWidget::buildAddressSchema()
 {
@@ -281,6 +283,30 @@ void TestAddRegisterWidget::switchAdapterRebuildsSchema()
     QVERIFY(_pRegWidget->_addressSchema["properties"].toObject().contains(QStringLiteral("channel")));
     QCOMPARE(_pRegWidget->_dataPointDefaults["channel"].toInt(), 3);
     QCOMPARE(_pRegWidget->_pAddressForm->values()["channel"].toInt(), 3);
+}
+
+void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
+{
+    addSimAdapter();
+
+    QMenu menu;
+    auto* action = new QWidgetAction(&menu);
+    action->setDefaultWidget(_pRegWidget);
+    menu.addAction(action);
+
+    /* Showing forces the menu to adopt the widget and size itself, as happens
+     * the first time RegisterDialog's btnAdd popup is opened. */
+    menu.show();
+    const int heightWithFourFields = menu.height();
+
+    /* Switch, while the popup is open, from modbus (4 fields) to sim (1 field) */
+    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+
+    QVERIFY(menu.height() < heightWithFourFields);
+
+    menu.hide();
+    /* Ownership of _pRegWidget transferred to menu when shown; avoid double delete in cleanup() */
+    _pRegWidget = nullptr;
 }
 
 void TestAddRegisterWidget::buildExpressionRoutedToSelectedAdapter()

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -305,7 +305,17 @@ void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
     QVERIFY(menu.height() < heightWithFourFields);
 
     menu.hide();
-    /* Ownership of _pRegWidget transferred to menu when shown; avoid double delete in cleanup() */
+
+    /* QWidgetAction::setDefaultWidget() reparents the widget into whichever container
+     * displays it, but ~QWidgetAction() unconditionally deletes the default widget too.
+     * If the widget were still a child of `menu` when `menu` is destroyed below, both
+     * menu's own child cleanup and the action's destructor would try to delete it,
+     * causing a double free. releaseWidget() detaches it (parent -> nullptr) first, so
+     * only the action's destructor deletes it. */
+    action->releaseWidget(_pRegWidget);
+
+    /* Ownership remains with `action` (destroyed below with `menu`); avoid a double
+     * delete in cleanup(). */
     _pRegWidget = nullptr;
 }
 

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -74,6 +74,7 @@ private slots:
     void adapterComboHiddenWithSingleAdapter();
     void adapterComboListsAdapters();
     void switchAdapterRebuildsSchema();
+    void switchAdapterWhileMenuOpenResizesPopup();
     void buildExpressionRoutedToSelectedAdapter();
     void btnAddDisabledWhenSelectedAdapterHasNoDevices();
 


### PR DESCRIPTION
QMenu caches its size when shown and doesn't notice that an embedded
QWidgetAction widget's content changed size, so switching adapters
while the popup is open left it clipped to the first adapter shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Add Register popup not resizing correctly after changing adapter types or completing an address expression.
  * Popup menus now automatically adjust their height to match the currently displayed address fields, keeping the form fully visible and avoiding excess empty space.

* **Tests**
  * Added regression coverage for resizing an open popup when switching between adapter configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->