### PR TITLE
Dev/refactor addregister widget

### DIFF
--- a/src/customwidgets/schemaformwidget.cpp
+++ b/src/customwidgets/schemaformwidget.cpp
@@ -70,14 +70,7 @@ void SchemaFormWidget::setSchema(const QJsonObject& schema, const QJsonObject& v
 
     for (const auto& key : orderedKeys)
     {
-        QJsonObject propSchema = properties.value(key).toObject();
-        QJsonValue currentValue = values.value(key);
-
-        QString label = propSchema.value("title").toString(key);
-        QWidget* widget = createWidgetForProperty(propSchema, currentValue);
-        wireFieldChanged(key, widget);
-        _fields.append({ key, widget });
-        _pFormLayout->addRow(label + ":", widget);
+        addFieldRow(key, properties.value(key).toObject(), values.value(key));
     }
 
     if (!parseConditional(schema))
@@ -85,26 +78,19 @@ void SchemaFormWidget::setSchema(const QJsonObject& schema, const QJsonObject& v
         return;
     }
 
+    /* addFieldRow() shows every row unconditionally, including these then/else fields, so the
+     * applyConditional() call below - which runs synchronously before this function returns -
+     * must stay in place to hide whichever branch isn't active. */
     const QJsonObject thenProps = schema.value("then").toObject().value("properties").toObject();
     for (const QString& key : std::as_const(_thenKeys))
     {
-        QJsonObject propSchema = thenProps.value(key).toObject();
-        QString label = propSchema.value("title").toString(key);
-        QWidget* widget = createWidgetForProperty(propSchema, values.value(key));
-        wireFieldChanged(key, widget);
-        _fields.append({ key, widget });
-        _pFormLayout->addRow(label + ":", widget);
+        addFieldRow(key, thenProps.value(key).toObject(), values.value(key));
     }
 
     const QJsonObject elseProps = schema.value("else").toObject().value("properties").toObject();
     for (const QString& key : std::as_const(_elseKeys))
     {
-        QJsonObject propSchema = elseProps.value(key).toObject();
-        QString label = propSchema.value("title").toString(key);
-        QWidget* widget = createWidgetForProperty(propSchema, values.value(key));
-        wireFieldChanged(key, widget);
-        _fields.append({ key, widget });
-        _pFormLayout->addRow(label + ":", widget);
+        addFieldRow(key, elseProps.value(key).toObject(), values.value(key));
     }
 
     QComboBox* triggerCombo = nullptr;
@@ -125,6 +111,34 @@ void SchemaFormWidget::setSchema(const QJsonObject& schema, const QJsonObject& v
     else
     {
         applyConditional(values.value(_conditionalTriggerKey).toVariant().toString());
+    }
+}
+
+/*!
+ * \brief Builds the widget for \a key, wires it up, and adds it as a row.
+ *
+ * Explicitly shows the new field widget and its label: a widget created under an
+ * already-visible parent doesn't inherit visibility on its own (it only picks it up on
+ * the next event loop turn, when its ancestor's deferred child-show catches up), so
+ * QFormLayout treats it as hidden and reports a QSize(0, 0) row until then. Left alone,
+ * that made AddRegisterWidget::resizeContainingMenu()'s immediate sizeHint() query see a
+ * too-small form whenever setSchema() added more rows than the previous schema had.
+ * \param key        Schema property key, used to look up the field's current value later.
+ * \param propSchema Schema fragment describing this single property.
+ * \param value      Current value for the property.
+ */
+void SchemaFormWidget::addFieldRow(const QString& key, const QJsonObject& propSchema, const QJsonValue& value)
+{
+    QString label = propSchema.value("title").toString(key);
+    QWidget* widget = createWidgetForProperty(propSchema, value);
+    wireFieldChanged(key, widget);
+    _fields.append({ key, widget });
+    _pFormLayout->addRow(label + ":", widget);
+
+    widget->show();
+    if (QWidget* fieldLabel = _pFormLayout->labelForField(widget))
+    {
+        fieldLabel->show();
     }
 }
 

--- a/src/customwidgets/schemaformwidget.h
+++ b/src/customwidgets/schemaformwidget.h
@@ -55,6 +55,8 @@ private slots:
 private:
     QWidget* createWidgetForProperty(const QJsonObject& propSchema, const QJsonValue& value);
 
+    void addFieldRow(const QString& key, const QJsonObject& propSchema, const QJsonValue& value);
+
     //! If \a widget is a QLineEdit, connects its textChanged to emit fieldChanged(\a key).
     void wireFieldChanged(const QString& key, QWidget* widget);
 

--- a/src/dialogs/adapterdevicesettings.cpp
+++ b/src/dialogs/adapterdevicesettings.cpp
@@ -56,6 +56,8 @@ AdapterDeviceSettings::AdapterDeviceSettings(SettingsModel* pSettingsModel, QWid
         }
     }
 
+    /* Must run before the tab-building loop below: that loop's ownership check assumes
+     * device ownership is already reconciled. */
     pSettingsModel->reconcileDevicesWithAdapters();
 
     QList<QWidget*> pages;
@@ -75,6 +77,17 @@ AdapterDeviceSettings::AdapterDeviceSettings(SettingsModel* pSettingsModel, QWid
                 const deviceId_t devId = static_cast<deviceId_t>(id);
                 if (seenDeviceIds.contains(devId))
                 {
+                    continue;
+                }
+                if (pSettingsModel->hasDevice(devId) && pSettingsModel->adapterIdForDevice(devId) != adapterId)
+                {
+                    /* reconcileDevicesWithAdapters() above already resolved this device ID to a
+                     * different adapter (e.g. that adapter has an explicit stored config, while
+                     * this one still only shares the ID in its untouched defaults). Skip it here
+                     * so its tab is built from the reconciled owner's own declaration below,
+                     * instead of from this adapter's declaration purely because it was iterated
+                     * first — building it from the wrong adapter would make acceptValues() write
+                     * an empty devices array back to the real owner, wiping its stored config. */
                     continue;
                 }
                 seenDeviceIds.insert(devId);

--- a/src/dialogs/adapterdevicesettings.cpp
+++ b/src/dialogs/adapterdevicesettings.cpp
@@ -56,6 +56,8 @@ AdapterDeviceSettings::AdapterDeviceSettings(SettingsModel* pSettingsModel, QWid
         }
     }
 
+    pSettingsModel->reconcileDevicesWithAdapters();
+
     QList<QWidget*> pages;
     QStringList names;
     QSet<deviceId_t> seenDeviceIds;
@@ -76,8 +78,6 @@ AdapterDeviceSettings::AdapterDeviceSettings(SettingsModel* pSettingsModel, QWid
                     continue;
                 }
                 seenDeviceIds.insert(devId);
-                pSettingsModel->addDevice(devId);
-                pSettingsModel->deviceSettings(devId)->setAdapterId(adapterId);
             }
             auto* tab = new DeviceConfigTab(pSettingsModel, adapterId, deviceObj, _pDeviceTabs);
             connectTabNameTracking(tab);

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -8,8 +8,10 @@
 #include "models/device.h"
 #include "models/settingsmodel.h"
 
+#include <QCoreApplication>
 #include <QJsonArray>
 #include <QMenu>
+#include <QResizeEvent>
 #include <QVBoxLayout>
 
 /*!
@@ -142,16 +144,25 @@ void AddRegisterWidget::rebuildAddressForm()
  * \brief Resizes the enclosing popup menu to fit this widget's current content.
  *
  * When hosted as a QWidgetAction's default widget inside a QToolButton's popup menu (as
- * RegisterDialog does for btnAdd), QMenu computes and caches its size when shown and does not
- * observe later size changes of an already-embedded widget. Without this, switching adapters
- * while the popup is open leaves it clipped to whichever adapter was shown first.
+ * RegisterDialog does for btnAdd), QMenu caches its action layout and only recomputes it for
+ * specific events (its action list changing, being shown, or being resized) - it has no way to
+ * know an already-embedded widget's own content changed. Without this, switching adapters while
+ * the popup is open leaves it clipped to whichever adapter was shown first. A synthetic resize
+ * event forces QMenu to mark its cached layout dirty and recompute it, so the sizeHint() below
+ * reflects the rebuilt form instead of stale, cached action rects.
  */
 void AddRegisterWidget::resizeContainingMenu()
 {
-    if (auto* menu = qobject_cast<QMenu*>(window()))
+    auto* menu = qobject_cast<QMenu*>(window());
+    if (menu == nullptr)
     {
-        menu->resize(menu->sizeHint());
+        return;
     }
+
+    QResizeEvent resizeEvent(menu->size(), menu->size());
+    QCoreApplication::sendEvent(menu, &resizeEvent);
+
+    menu->resize(menu->sizeHint());
 }
 
 /*!

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -9,6 +9,7 @@
 #include "models/settingsmodel.h"
 
 #include <QJsonArray>
+#include <QMenu>
 #include <QVBoxLayout>
 
 /*!
@@ -124,6 +125,8 @@ void AddRegisterWidget::applyAdapter(const QString& adapterId)
     rebuildAddressForm();
 
     _pUi->btnAdd->setEnabled(isAdapterUsable(adapterId));
+
+    resizeContainingMenu();
 }
 
 /*!
@@ -132,6 +135,22 @@ void AddRegisterWidget::applyAdapter(const QString& adapterId)
 void AddRegisterWidget::rebuildAddressForm()
 {
     _pAddressForm->setSchema(_addressSchema, _dataPointDefaults);
+}
+
+/*!
+ * \brief Resizes the enclosing popup menu to fit this widget's current content.
+ *
+ * When hosted as a QWidgetAction's default widget inside a QToolButton's popup menu (as
+ * RegisterDialog does for btnAdd), QMenu computes and caches its size when shown and does not
+ * observe later size changes of an already-embedded widget. Without this, switching adapters
+ * while the popup is open leaves it clipped to whichever adapter was shown first.
+ */
+void AddRegisterWidget::resizeContainingMenu()
+{
+    if (auto* menu = qobject_cast<QMenu*>(window()))
+    {
+        menu->resize(menu->sizeHint());
+    }
 }
 
 /*!

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -107,7 +107,8 @@ QJsonObject AddRegisterWidget::buildSchema(const QString& adapterId) const
  * \brief Switch the widget to the given adapter's register schema.
  *
  * Rebuilds the address form from the adapter's data point schema and updates
- * the add button state based on manager and device availability.
+ * the add button state based on manager and device availability. Also resizes
+ * the enclosing popup menu, if any, to fit the rebuilt form.
  * \param adapterId Identifier of the adapter to use.
  */
 void AddRegisterWidget::applyAdapter(const QString& adapterId)
@@ -220,6 +221,7 @@ void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
 
     resetFields();
     rebuildAddressForm();
+    resizeContainingMenu();
 }
 
 void AddRegisterWidget::resetFields()

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -15,10 +15,10 @@
 #include <QVBoxLayout>
 
 /*!
- * \brief Constructs the widget and populates it from the selected adapter's register schema.
+ * \brief Constructs the widget and populates it from the selected device's register schema.
  *
- * The adapter selector is filled with all discovered adapters and hidden when
- * only a single adapter is available.
+ * The device selector is filled with all configured devices and hidden when
+ * only a single device is available.
  * \param pSettingsModel Pointer to the application settings model.
  * \param pAdapterHub    Pointer to the adapter hub used to look up adapter managers.
  * \param parent         Optional parent widget.
@@ -43,20 +43,10 @@ AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel, AdapterHub* 
     addressLayout->setContentsMargins(0, 0, 0, 0);
     addressLayout->addWidget(_pAddressForm);
 
-    const QStringList adapterIds = _pAdapterHub->adapterIds();
-    for (const QString& adapterId : adapterIds)
-    {
-        QString label = _pSettingsModel->adapterData(adapterId)->name();
-        if (label.isEmpty())
-        {
-            label = adapterId;
-        }
-        _pUi->cmbAdapter->addItem(label, adapterId);
-    }
-    _pUi->cmbAdapter->setVisible(adapterIds.size() > 1);
+    populateDeviceCombo();
 
     /* Connect after populating to avoid spurious slot calls during addItem */
-    connect(_pUi->cmbAdapter, &QComboBox::currentIndexChanged, this, &AddRegisterWidget::onAdapterSelectionChanged);
+    connect(_pUi->cmbDevice, &QComboBox::currentIndexChanged, this, &AddRegisterWidget::onDeviceSelectionChanged);
 
     connect(_pUi->btnAdd, &QPushButton::clicked, this, &AddRegisterWidget::handleResultAccept);
 
@@ -64,8 +54,24 @@ AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel, AdapterHub* 
     _axisGroup.addButton(_pUi->radioPrimary);
     _axisGroup.addButton(_pUi->radioSecondary);
 
-    applyAdapter(selectedAdapterId());
+    applyDevice(selectedDeviceId());
     resetFields();
+}
+
+/*!
+ * \brief Fills the device combo box with all configured devices.
+ *
+ * The combo is hidden when only a single device is configured, since there is
+ * nothing to choose between.
+ */
+void AddRegisterWidget::populateDeviceCombo()
+{
+    const QList<deviceId_t> deviceIds = _pSettingsModel->deviceList();
+    for (deviceId_t devId : deviceIds)
+    {
+        _pUi->cmbDevice->addItem(_pSettingsModel->deviceSettings(devId)->name(), QVariant(devId));
+    }
+    _pUi->cmbDevice->setVisible(deviceIds.size() > 1);
 }
 
 AddRegisterWidget::~AddRegisterWidget()
@@ -74,60 +80,88 @@ AddRegisterWidget::~AddRegisterWidget()
 }
 
 /*!
- * \brief Build the address schema patched with available devices as a deviceId enum.
- * \param adapterId Adapter whose data point schema and device list to use.
- * \return The patched schema object ready for SchemaFormWidget.
+ * \brief Build the address schema with the adapter's own deviceId field stripped out.
+ *
+ * The device is already fixed by the outer device selection, so the adapter's
+ * addressSchema (which may declare its own generic deviceId field) must not
+ * render a second, redundant device picker inside the address form.
+ * \param adapterData Adapter whose data point schema to use.
+ * \return The schema object ready for SchemaFormWidget, without a deviceId property.
  */
-QJsonObject AddRegisterWidget::buildSchema(const QString& adapterId) const
+QJsonObject AddRegisterWidget::buildSchema(const AdapterData* adapterData) const
 {
-    const AdapterData* adapterData = _pSettingsModel->adapterData(adapterId);
     QJsonObject schema = adapterData->dataPointSchema().value("addressSchema").toObject();
-
-    const auto deviceList = _pSettingsModel->deviceListForAdapter(adapterId);
-    QJsonArray deviceEnum;
-    QJsonArray deviceLabels;
-    for (deviceId_t devId : deviceList)
-    {
-        deviceEnum.append(static_cast<int>(devId));
-        deviceLabels.append(tr("Device %1").arg(devId));
-    }
 
     QJsonObject propsObj = schema.value("properties").toObject();
     if (propsObj.contains(QStringLiteral("deviceId")))
     {
-        QJsonObject deviceIdProp = propsObj.value("deviceId").toObject();
-        deviceIdProp["enum"] = deviceEnum;
-        deviceIdProp["x-enumLabels"] = deviceLabels;
-        propsObj["deviceId"] = deviceIdProp;
+        propsObj.remove(QStringLiteral("deviceId"));
         schema["properties"] = propsObj;
+
+        QJsonArray required = schema.value("required").toArray();
+        for (int i = 0; i < required.size(); ++i)
+        {
+            if (required.at(i).toString() == QStringLiteral("deviceId"))
+            {
+                required.removeAt(i);
+                schema["required"] = required;
+                break;
+            }
+        }
     }
 
     return schema;
 }
 
 /*!
- * \brief Switch the widget to the given adapter's register schema.
+ * \brief Switch the widget to the given device's adapter and register schema.
  *
- * Rebuilds the address form from the adapter's data point schema and updates
- * the add button state based on manager and device availability. Also resizes
+ * Rebuilds the address form from the device's adapter's data point schema and
+ * updates the add button state based on manager availability. Also resizes
  * the enclosing popup menu, if any, to fit the rebuilt form.
- * \param adapterId Identifier of the adapter to use.
+ * \param deviceId Identifier of the device to use.
  */
-void AddRegisterWidget::applyAdapter(const QString& adapterId)
+void AddRegisterWidget::applyDevice(deviceId_t deviceId)
 {
-    _pAdapterManager = _pAdapterHub->adapterManager(adapterId);
-    if (_pAdapterManager == nullptr)
+    if (_pUi->cmbDevice->count() == 0)
     {
+        _pAdapterManager = nullptr;
+        _pUi->lblProtocol->clear();
         _pUi->btnAdd->setEnabled(false);
         return;
     }
 
-    const QJsonObject dataPointSchema = _pSettingsModel->adapterData(adapterId)->dataPointSchema();
-    _addressSchema = buildSchema(adapterId);
-    _dataPointDefaults = dataPointSchema["defaults"].toObject();
+    const QString adapterId = _pSettingsModel->adapterIdForDevice(deviceId);
+    _pAdapterManager = _pAdapterHub->adapterManager(adapterId);
+
+    if (_pAdapterManager == nullptr)
+    {
+        /* Adapter isn't currently discovered/running: show the bare id rather than
+         * looking it up (adapterData() would otherwise insert a phantom entry for
+         * an id that was never actually registered), and clear the stale form from
+         * whichever device was selected before. */
+        _pUi->lblProtocol->setText(tr("Protocol: %1").arg(adapterId));
+        _addressSchema = QJsonObject();
+        _dataPointDefaults = QJsonObject();
+        rebuildAddressForm();
+        _pUi->btnAdd->setEnabled(false);
+        resizeContainingMenu();
+        return;
+    }
+
+    const AdapterData* adapterData = _pSettingsModel->adapterData(adapterId);
+    QString protocolLabel = adapterData->name();
+    if (protocolLabel.isEmpty())
+    {
+        protocolLabel = adapterId;
+    }
+    _pUi->lblProtocol->setText(tr("Protocol: %1").arg(protocolLabel));
+
+    _addressSchema = buildSchema(adapterData);
+    _dataPointDefaults = adapterData->dataPointSchema().value("defaults").toObject();
     rebuildAddressForm();
 
-    _pUi->btnAdd->setEnabled(isAdapterUsable(adapterId));
+    _pUi->btnAdd->setEnabled(isSelectionUsable());
 
     resizeContainingMenu();
 }
@@ -146,8 +180,8 @@ void AddRegisterWidget::rebuildAddressForm()
  * When hosted as a QWidgetAction's default widget inside a QToolButton's popup menu (as
  * RegisterDialog does for btnAdd), QMenu caches its action layout and only recomputes it for
  * specific events (its action list changing, being shown, or being resized) - it has no way to
- * know an already-embedded widget's own content changed. Without this, switching adapters while
- * the popup is open leaves it clipped to whichever adapter was shown first. A synthetic resize
+ * know an already-embedded widget's own content changed. Without this, switching devices while
+ * the popup is open leaves it clipped to whichever device's form was shown first. A synthetic resize
  * event forces QMenu to mark its cached layout dirty and recompute it, so the sizeHint() below
  * reflects the rebuilt form instead of stale, cached action rects.
  */
@@ -166,34 +200,32 @@ void AddRegisterWidget::resizeContainingMenu()
 }
 
 /*!
- * \brief Returns whether the given adapter has a manager and at least one configured device.
- * \param adapterId Identifier of the adapter to check.
+ * \brief Returns whether the currently selected device's adapter has a live manager.
  */
-bool AddRegisterWidget::isAdapterUsable(const QString& adapterId) const
+bool AddRegisterWidget::isSelectionUsable() const
 {
-    return (_pAdapterHub->adapterManager(adapterId) != nullptr) &&
-           !_pSettingsModel->deviceListForAdapter(adapterId).isEmpty();
+    return _pAdapterManager != nullptr;
 }
 
 /*!
- * \brief Returns the adapter ID of the adapter currently selected in the adapter combo box.
+ * \brief Returns the ID of the device currently selected in the device combo box.
  */
-QString AddRegisterWidget::selectedAdapterId() const
+deviceId_t AddRegisterWidget::selectedDeviceId() const
 {
-    return _pUi->cmbAdapter->currentData().toString();
+    return static_cast<deviceId_t>(_pUi->cmbDevice->currentData().toUInt());
 }
 
 /*!
- * \brief Rebuilds the address form when another adapter is selected.
+ * \brief Rebuilds the address form when another device is selected.
  *
- * The curve name and axis selection are kept so switching adapters only
+ * The curve name and axis selection are kept so switching devices only
  * replaces the address fields.
  * \param index Index of the newly selected combo box entry (unused).
  */
-void AddRegisterWidget::onAdapterSelectionChanged(int index)
+void AddRegisterWidget::onDeviceSelectionChanged(int index)
 {
     Q_UNUSED(index);
-    applyAdapter(selectedAdapterId());
+    applyDevice(selectedDeviceId());
 }
 
 void AddRegisterWidget::handleResultAccept()
@@ -207,8 +239,7 @@ void AddRegisterWidget::handleResultAccept()
 
     QJsonObject allValues = _pAddressForm->values();
     const QString dataType = allValues.take(QStringLiteral("dataType")).toString();
-    const deviceId_t deviceId =
-      static_cast<deviceId_t>(allValues.take(QStringLiteral("deviceId")).toInt(Device::cFirstDeviceId));
+    const deviceId_t deviceId = selectedDeviceId();
 
     _pUi->btnAdd->setEnabled(false);
     connect(_pAdapterManager, &AdapterManager::buildExpressionResult, this, &AddRegisterWidget::onBuildExpressionResult,
@@ -219,8 +250,8 @@ void AddRegisterWidget::handleResultAccept()
 void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
 {
     /* Recompute instead of unconditionally enabling: the user may have switched
-     * to an adapter without devices while the request was in flight */
-    _pUi->btnAdd->setEnabled(isAdapterUsable(selectedAdapterId()));
+     * to a device whose adapter is unavailable while the request was in flight */
+    _pUi->btnAdd->setEnabled(isSelectionUsable());
 
     if (expression.isEmpty())
     {

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -17,8 +17,7 @@
 /*!
  * \brief Constructs the widget and populates it from the selected device's register schema.
  *
- * The device selector is filled with all configured devices and hidden when
- * only a single device is available.
+ * The device selector is filled with all configured devices.
  * \param pSettingsModel Pointer to the application settings model.
  * \param pAdapterHub    Pointer to the adapter hub used to look up adapter managers.
  * \param parent         Optional parent widget.
@@ -60,9 +59,6 @@ AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel, AdapterHub* 
 
 /*!
  * \brief Fills the device combo box with all configured devices.
- *
- * The combo is hidden when only a single device is configured, since there is
- * nothing to choose between.
  */
 void AddRegisterWidget::populateDeviceCombo()
 {
@@ -71,7 +67,6 @@ void AddRegisterWidget::populateDeviceCombo()
     {
         _pUi->cmbDevice->addItem(_pSettingsModel->deviceSettings(devId)->name(), QVariant(devId));
     }
-    _pUi->cmbDevice->setVisible(deviceIds.size() > 1);
 }
 
 AddRegisterWidget::~AddRegisterWidget()

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -40,6 +40,7 @@ private:
     void collectPendingGraphData();
     void applyAdapter(const QString& adapterId);
     void rebuildAddressForm();
+    void resizeContainingMenu();
     bool isAdapterUsable(const QString& adapterId) const;
     QString selectedAdapterId() const;
     QJsonObject buildSchema(const QString& adapterId) const;

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -8,6 +8,7 @@
 #include <QJsonObject>
 #include <QWidget>
 
+class AdapterData;
 class AdapterHub;
 class AdapterManager;
 class SchemaFormWidget;
@@ -33,17 +34,18 @@ signals:
 private slots:
     void handleResultAccept();
     void onBuildExpressionResult(const QString& expression);
-    void onAdapterSelectionChanged(int index);
+    void onDeviceSelectionChanged(int index);
 
 private:
     void resetFields();
     void collectPendingGraphData();
-    void applyAdapter(const QString& adapterId);
+    void populateDeviceCombo();
+    void applyDevice(deviceId_t deviceId);
     void rebuildAddressForm();
     void resizeContainingMenu();
-    bool isAdapterUsable(const QString& adapterId) const;
-    QString selectedAdapterId() const;
-    QJsonObject buildSchema(const QString& adapterId) const;
+    bool isSelectionUsable() const;
+    deviceId_t selectedDeviceId() const;
+    QJsonObject buildSchema(const AdapterData* adapterData) const;
 
     Ui::AddRegisterWidget* _pUi;
     SchemaFormWidget* _pAddressForm;

--- a/src/dialogs/addregisterwidget.ui
+++ b/src/dialogs/addregisterwidget.ui
@@ -30,19 +30,26 @@
        <number>6</number>
       </property>
       <item row="0" column="0" colspan="2">
-       <widget class="QComboBox" name="cmbAdapter"/>
+       <widget class="QComboBox" name="cmbDevice"/>
       </item>
       <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="lblProtocol">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
        <widget class="QLineEdit" name="lineName">
         <property name="text">
          <string>Name of curve</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QWidget" name="addressContainer" native="true"/>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QRadioButton" name="radioPrimary">
         <property name="text">
          <string>Y1 axis</string>
@@ -52,7 +59,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QRadioButton" name="radioSecondary">
         <property name="text">
          <string>Y2 axis</string>

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -81,7 +81,7 @@ RegisterDialog::RegisterDialog(GraphDataModel* pGraphDataModel,
     connect(_pUi->btnRemove, &QPushButton::released, this, &RegisterDialog::removeRegisterRow);
     connect(_pGraphDataModel, &GraphDataModel::rowsInserted, this, &RegisterDialog::onRegisterInserted);
 
-    if (!_pAdapterHub->adapterIds().isEmpty())
+    if (!_pSettingsModel->deviceList().isEmpty())
     {
         auto registerPopupMenu = new AddRegisterWidget(_pSettingsModel, _pAdapterHub, this);
         connect(registerPopupMenu, &AddRegisterWidget::graphDataConfigured, this, &RegisterDialog::addRegister);
@@ -165,23 +165,20 @@ void RegisterDialog::handleExpressionEdit(const QModelIndex& index)
 /*!
  * \brief Determine which adapter manager drives the default new-register expression.
  *
- * The modbus adapter is preferred to keep the existing single-adapter behavior;
- * when it is not available the first discovered adapter is used.
- * \return Pointer to the manager, or nullptr when no adapters are available.
+ * Uses the first configured device's adapter, consistent with AddRegisterWidget's
+ * device-first selection.
+ * \return Pointer to the manager, or nullptr when no devices are configured.
  */
 AdapterManager* RegisterDialog::defaultExpressionManager() const
 {
-    AdapterManager* pManager = _pAdapterHub->adapterManager(cModbusAdapterId);
-    if (pManager == nullptr)
+    const QList<deviceId_t> deviceIds = _pSettingsModel->deviceList();
+    if (deviceIds.isEmpty())
     {
-        const QStringList adapterIds = _pAdapterHub->adapterIds();
-        if (!adapterIds.isEmpty())
-        {
-            pManager = _pAdapterHub->adapterManager(adapterIds.first());
-        }
+        return nullptr;
     }
 
-    return pManager;
+    const QString adapterId = _pSettingsModel->adapterIdForDevice(deviceIds.first());
+    return _pAdapterHub->adapterManager(adapterId);
 }
 
 int RegisterDialog::selectedRowAfterDelete(int deletedStartIndex, int rowCnt)

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -229,8 +229,13 @@ bool SettingsModel::isMbcCompatible() const
 
 /*! \brief Persist a new configuration for an adapter and notify observers.
  *
- * Sets the adapter's current config and marks it as having a stored config,
- * then emits adapterDataChanged() so listeners can react.
+ * Sets the adapter's current config and marks it as having a stored config, then emits
+ * adapterDataChanged() so listeners can react. Deliberately does not reconcile device
+ * ownership itself: a device named in the stored config may not be meant to exist in
+ * \c _devices yet (e.g. a project file's devices section can omit a device the adapter
+ * config still lists) — registration and ownership stay driven by
+ * reconcileDevicesWithAdapters()'s own trigger points (updateAdapterFromDescribe() and
+ * AdapterDeviceSettings opening), not by every config write.
  * \param adapterId  The adapter identifier string.
  * \param config     The configuration JSON object to store.
  */
@@ -293,7 +298,7 @@ void SettingsModel::updateAdapterFromDescribe(const QString& adapterId, const QJ
     emit adapterDataChanged(adapterId);
 }
 
-/*! \brief Claim each adapter-declared default device ID for the first adapter that declares it.
+/*! \brief Claim each adapter-declared default device ID for the adapter that should own it.
  *
  * For every adapter with known schema, walks its effective config's device list and, for any
  * device ID not already claimed earlier in the resulting order, ensures the device exists and
@@ -311,6 +316,11 @@ void SettingsModel::updateAdapterFromDescribe(const QString& adapterId, const QJ
  * equally-configured) adapters still resolves deterministically, just not meaningfully — that
  * remaining tie only matters before either adapter has been explicitly configured.
  *
+ * Any code that needs to know which adapter owns a device must read it back via
+ * deviceSettings()/adapterIdForDevice() rather than re-deriving ownership itself (e.g. by picking
+ * the first adapter that declares a given device ID) — that would disagree with this method's
+ * tie-break and could silently discard the reconciled owner's config.
+ *
  * Deliberately does not remove devices no adapter currently declares — that pruning is only safe
  * once every relevant adapter's config is known, whereas this runs incrementally as each adapter
  * describes and must not delete devices belonging to adapters that simply haven't described yet.
@@ -321,7 +331,7 @@ void SettingsModel::reconcileDevicesWithAdapters()
     const QStringList allAdapterIds = adapterIds();
     for (const auto& id : allAdapterIds)
     {
-        if (!_adapters[id].schema().isEmpty())
+        if (!_adapters.value(id).schema().isEmpty())
         {
             validAdapterIds.append(id);
         }
@@ -330,14 +340,14 @@ void SettingsModel::reconcileDevicesWithAdapters()
     QStringList orderedAdapterIds;
     for (const auto& id : validAdapterIds)
     {
-        if (_adapters[id].hasStoredConfig())
+        if (_adapters.value(id).hasStoredConfig())
         {
             orderedAdapterIds.append(id);
         }
     }
     for (const auto& id : validAdapterIds)
     {
-        if (!_adapters[id].hasStoredConfig())
+        if (!_adapters.value(id).hasStoredConfig())
         {
             orderedAdapterIds.append(id);
         }
@@ -346,7 +356,7 @@ void SettingsModel::reconcileDevicesWithAdapters()
     QSet<deviceId_t> seenDeviceIds;
     for (const auto& adapterId : orderedAdapterIds)
     {
-        const QJsonArray devices = _adapters[adapterId].effectiveConfig().value("devices").toArray();
+        const QJsonArray devices = _adapters.value(adapterId).effectiveConfig().value("devices").toArray();
         for (const auto& device : devices)
         {
             const int id = device.toObject().value("id").toInt(-1);
@@ -361,8 +371,19 @@ void SettingsModel::reconcileDevicesWithAdapters()
                 continue;
             }
             seenDeviceIds.insert(devId);
+
+            const bool alreadyKnownDevice = _devices.contains(devId);
             addDevice(devId);
-            deviceSettings(devId)->setAdapterId(adapterId);
+            if (deviceSettings(devId)->adapterId() != adapterId)
+            {
+                deviceSettings(devId)->setAdapterId(adapterId);
+                if (alreadyKnownDevice)
+                {
+                    /* addDevice() only emits deviceListChanged() for brand-new devices; an
+                     * already-known device silently changing owner needs its own notification. */
+                    emit deviceListChanged();
+                }
+            }
         }
     }
 }

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -126,21 +126,6 @@ QList<deviceId_t> SettingsModel::deviceList()
     return list;
 }
 
-QList<deviceId_t> SettingsModel::deviceListForAdapter(const QString& adapterId)
-{
-    QList<deviceId_t> list;
-
-    for (auto i = _devices.cbegin(), end = _devices.cend(); i != end; ++i)
-    {
-        if (i.value().adapterId() == adapterId)
-        {
-            list.append(i.key());
-        }
-    }
-
-    return list;
-}
-
 /*! \brief Return the adapter ID that owns the given device.
  *
  * When the device is unknown, the adapter ID of a default-constructed Device

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -1,6 +1,9 @@
 #include "settingsmodel.h"
 #include "util/scopelogging.h"
 
+#include <QJsonArray>
+#include <QSet>
+
 namespace {
 
 /*!
@@ -263,6 +266,7 @@ void SettingsModel::updateAdapterFromDescribe(const QString& adapterId, const QJ
         _adapters[adapterId] = AdapterData();
     }
     _adapters[adapterId].updateFromDescribe(describeResult);
+    reconcileDevicesWithAdapters();
 
     const QString version = _adapters[adapterId].version();
     QString versionTxt("unknown version");
@@ -287,6 +291,80 @@ void SettingsModel::updateAdapterFromDescribe(const QString& adapterId, const QJ
     }
 
     emit adapterDataChanged(adapterId);
+}
+
+/*! \brief Claim each adapter-declared default device ID for the first adapter that declares it.
+ *
+ * For every adapter with known schema, walks its effective config's device list and, for any
+ * device ID not already claimed earlier in the resulting order, ensures the device exists and
+ * assigns it that adapter. This keeps a device ID shared by two adapters' defaults (e.g. both
+ * declaring device 1) consistently assigned to one adapter as soon as adapter data is available,
+ * instead of leaving it on Device's constructor default until the user opens Settings.
+ *
+ * Adapters with an explicitly saved config (hasStoredConfig()) are considered before adapters
+ * still on raw, never-configured defaults, so a device the user deliberately assigned to one
+ * adapter can't later be reclaimed by another adapter that merely happens to share that device ID
+ * in its untouched defaults — this method re-runs on every describe, including reconnects, so a
+ * once-off "first adapter alphabetically wins" rule would let a later reconnect silently steal a
+ * device back from its explicitly configured owner. Within each of those two groups, adapters are
+ * considered in adapterIds() order, so a device ID shared by two equally-unconfigured (or two
+ * equally-configured) adapters still resolves deterministically, just not meaningfully — that
+ * remaining tie only matters before either adapter has been explicitly configured.
+ *
+ * Deliberately does not remove devices no adapter currently declares — that pruning is only safe
+ * once every relevant adapter's config is known, whereas this runs incrementally as each adapter
+ * describes and must not delete devices belonging to adapters that simply haven't described yet.
+ */
+void SettingsModel::reconcileDevicesWithAdapters()
+{
+    QStringList validAdapterIds;
+    const QStringList allAdapterIds = adapterIds();
+    for (const auto& id : allAdapterIds)
+    {
+        if (!_adapters[id].schema().isEmpty())
+        {
+            validAdapterIds.append(id);
+        }
+    }
+
+    QStringList orderedAdapterIds;
+    for (const auto& id : validAdapterIds)
+    {
+        if (_adapters[id].hasStoredConfig())
+        {
+            orderedAdapterIds.append(id);
+        }
+    }
+    for (const auto& id : validAdapterIds)
+    {
+        if (!_adapters[id].hasStoredConfig())
+        {
+            orderedAdapterIds.append(id);
+        }
+    }
+
+    QSet<deviceId_t> seenDeviceIds;
+    for (const auto& adapterId : orderedAdapterIds)
+    {
+        const QJsonArray devices = _adapters[adapterId].effectiveConfig().value("devices").toArray();
+        for (const auto& device : devices)
+        {
+            const int id = device.toObject().value("id").toInt(-1);
+            if (id < 0)
+            {
+                continue;
+            }
+
+            const deviceId_t devId = static_cast<deviceId_t>(id);
+            if (seenDeviceIds.contains(devId))
+            {
+                continue;
+            }
+            seenDeviceIds.insert(devId);
+            addDevice(devId);
+            deviceSettings(devId)->setAdapterId(adapterId);
+        }
+    }
 }
 
 bool SettingsModel::hasDevice(deviceId_t devId) const

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -354,6 +354,7 @@ void SettingsModel::reconcileDevicesWithAdapters()
     }
 
     QSet<deviceId_t> seenDeviceIds;
+    bool ownerChanged = false;
     for (const auto& adapterId : orderedAdapterIds)
     {
         const QJsonArray devices = _adapters.value(adapterId).effectiveConfig().value("devices").toArray();
@@ -380,11 +381,17 @@ void SettingsModel::reconcileDevicesWithAdapters()
                 if (alreadyKnownDevice)
                 {
                     /* addDevice() only emits deviceListChanged() for brand-new devices; an
-                     * already-known device silently changing owner needs its own notification. */
-                    emit deviceListChanged();
+                     * already-known device silently changing owner needs its own notification,
+                     * deferred until the end so a pass reassigning several devices only emits once. */
+                    ownerChanged = true;
                 }
             }
         }
+    }
+
+    if (ownerChanged)
+    {
+        emit deviceListChanged();
     }
 }
 

--- a/src/models/settingsmodel.h
+++ b/src/models/settingsmodel.h
@@ -44,6 +44,7 @@ public:
     void setAdapterCurrentConfig(const QString& adapterId, const QJsonObject& config);
     void updateAdapterFromDescribe(const QString& adapterId, const QJsonObject& describeResult);
     void setAdapterDataPointSchema(const QString& adapterId, const QJsonObject& schema);
+    void reconcileDevicesWithAdapters();
 
     static const QString defaultLogPath()
     {

--- a/src/models/settingsmodel.h
+++ b/src/models/settingsmodel.h
@@ -34,7 +34,6 @@ public:
     bool hasDevice(deviceId_t devId) const;
 
     QList<deviceId_t> deviceList();
-    QList<deviceId_t> deviceListForAdapter(const QString& adapterId);
     QString adapterIdForDevice(deviceId_t devId) const;
 
     const AdapterData* adapterData(const QString& adapterId);

--- a/tests/dialogs/tst_adapterdevicesettings.cpp
+++ b/tests/dialogs/tst_adapterdevicesettings.cpp
@@ -10,6 +10,7 @@
 #include <QJsonObject>
 #include <QLabel>
 #include <QLineEdit>
+#include <QSignalSpy>
 #include <QSpinBox>
 #include <QTest>
 
@@ -59,6 +60,23 @@ QJsonObject makeAdapterDescribe(const QString& adapterName)
     describe["schema"] = schema;
     describe["defaults"] = QJsonObject();
     describe["capabilities"] = QJsonObject();
+    return describe;
+}
+
+//! Build a describe result like makeAdapterDescribe(), but with a "defaults" section
+//! declaring a single untouched-default device with the given ID.
+QJsonObject makeAdapterDescribeWithDefaultDevice(const QString& adapterName, int deviceId)
+{
+    QJsonObject describe = makeAdapterDescribe(adapterName);
+
+    QJsonObject defaultDevice;
+    defaultDevice["id"] = deviceId;
+    QJsonObject defaults;
+    defaults["devices"] = QJsonArray{ defaultDevice };
+    defaults["connections"] = QJsonArray();
+    defaults["general"] = QJsonObject();
+    describe["defaults"] = defaults;
+
     return describe;
 }
 
@@ -671,19 +689,8 @@ void TestAdapterDeviceSettings::twoAdaptersWithSameDefaultDeviceIdShowsSingleTab
 {
     SettingsModel model;
 
-    auto makeDescribeWithDefault = [](const QString& name) {
-        QJsonObject describe = makeAdapterDescribe(name);
-        QJsonObject defaultDevice;
-        defaultDevice["id"] = 1;
-        QJsonObject defaults;
-        defaults["devices"] = QJsonArray{ defaultDevice };
-        defaults["connections"] = QJsonArray();
-        defaults["general"] = QJsonObject();
-        describe["defaults"] = defaults;
-        return describe;
-    };
-    model.updateAdapterFromDescribe("adapterA", makeDescribeWithDefault("adapterA"));
-    model.updateAdapterFromDescribe("adapterB", makeDescribeWithDefault("adapterB"));
+    model.updateAdapterFromDescribe("adapterA", makeAdapterDescribeWithDefaultDevice("adapterA", 1));
+    model.updateAdapterFromDescribe("adapterB", makeAdapterDescribeWithDefaultDevice("adapterB", 1));
 
     QVERIFY(!model.adapterData("adapterA")->hasStoredConfig());
     QVERIFY(!model.adapterData("adapterB")->hasStoredConfig());
@@ -727,22 +734,10 @@ void TestAdapterDeviceSettings::sharedDefaultDeviceIdReconciledOnDescribeWithout
 {
     SettingsModel model;
 
-    auto makeDescribeWithDefault = [](const QString& name) {
-        QJsonObject describe = makeAdapterDescribe(name);
-        QJsonObject defaultDevice;
-        defaultDevice["id"] = 1;
-        QJsonObject defaults;
-        defaults["devices"] = QJsonArray{ defaultDevice };
-        defaults["connections"] = QJsonArray();
-        defaults["general"] = QJsonObject();
-        describe["defaults"] = defaults;
-        return describe;
-    };
-
     // No AdapterDeviceSettings is constructed here: reconciliation must happen as soon as
     // adapters describe, not only when the user opens Settings.
-    model.updateAdapterFromDescribe("adapterA", makeDescribeWithDefault("adapterA"));
-    model.updateAdapterFromDescribe("adapterB", makeDescribeWithDefault("adapterB"));
+    model.updateAdapterFromDescribe("adapterA", makeAdapterDescribeWithDefaultDevice("adapterA", 1));
+    model.updateAdapterFromDescribe("adapterB", makeAdapterDescribeWithDefaultDevice("adapterB", 1));
 
     QCOMPARE(model.deviceList().size(), 1);
     QVERIFY(model.hasDevice(1));
@@ -753,21 +748,9 @@ void TestAdapterDeviceSettings::explicitDeviceAssignmentSurvivesLaterAdapterRede
 {
     SettingsModel model;
 
-    auto makeDescribeWithDefault = [](const QString& name) {
-        QJsonObject describe = makeAdapterDescribe(name);
-        QJsonObject defaultDevice;
-        defaultDevice["id"] = 1;
-        QJsonObject defaults;
-        defaults["devices"] = QJsonArray{ defaultDevice };
-        defaults["connections"] = QJsonArray();
-        defaults["general"] = QJsonObject();
-        describe["defaults"] = defaults;
-        return describe;
-    };
-
     // Both adapters declare device 1 in their raw, never-configured defaults.
-    model.updateAdapterFromDescribe("adapterA", makeDescribeWithDefault("adapterA"));
-    model.updateAdapterFromDescribe("adapterB", makeDescribeWithDefault("adapterB"));
+    model.updateAdapterFromDescribe("adapterA", makeAdapterDescribeWithDefaultDevice("adapterA", 1));
+    model.updateAdapterFromDescribe("adapterB", makeAdapterDescribeWithDefaultDevice("adapterB", 1));
 
     // adapterA wins the shared ID while neither adapter has an explicit config yet.
     QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterA"));
@@ -785,9 +768,78 @@ void TestAdapterDeviceSettings::explicitDeviceAssignmentSurvivesLaterAdapterRede
 
     // adapterA reconnects and redescribes; its raw defaults still declare device 1, but the
     // explicit assignment to adapterB must survive rather than be silently reclaimed by adapterA.
-    model.updateAdapterFromDescribe("adapterA", makeDescribeWithDefault("adapterA"));
+    model.updateAdapterFromDescribe("adapterA", makeAdapterDescribeWithDefaultDevice("adapterA", 1));
 
     QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterB"));
+}
+
+void TestAdapterDeviceSettings::dialogBuildsTabFromReconciledOwnerNotFirstAdapter()
+{
+    SettingsModel model;
+
+    // adapterA is alphabetically first and declares device 1 in its untouched defaults,
+    // but is never explicitly configured.
+    model.updateAdapterFromDescribe("adapterA", makeAdapterDescribeWithDefaultDevice("adapterA", 1));
+
+    // adapterB has an explicit stored config that also declares device 1.
+    QJsonObject devB;
+    devB["id"] = 1;
+    setupAdapter(model, "adapterB", QJsonArray{ devB });
+
+    // AdapterDeviceSettings's constructor reconciles device ownership itself before
+    // building tabs (see reconcileDevicesWithAdapters() called at construction time),
+    // so it must resolve device 1 to adapterB (stored config wins) regardless of
+    // adapter iteration order.
+    AdapterDeviceSettings w(&model);
+
+    auto* tabs = w.findChild<AddableTabWidget*>();
+    QVERIFY(tabs != nullptr);
+    QCOMPARE(tabs->count(), 1);
+
+    // The single tab must be built from device 1's reconciled owner, adapterB — not from
+    // adapterA, which merely happens to come first in adapter iteration order.
+    auto* tab = qobject_cast<DeviceConfigTab*>(tabs->tabContent(0));
+    QVERIFY(tab != nullptr);
+    QCOMPARE(tab->adapterId(), QStringLiteral("adapterB"));
+
+    w.acceptValues();
+
+    // Accepting must not wipe adapterB's stored device out from under it, nor let adapterA
+    // silently claim it.
+    QCOMPARE(model.adapterData("adapterB")->currentConfig().value("devices").toArray().size(), 1);
+    QCOMPARE(model.adapterData("adapterA")->currentConfig().value("devices").toArray().size(), 0);
+}
+
+void TestAdapterDeviceSettings::reassigningExistingDeviceOwnerEmitsDeviceListChanged()
+{
+    SettingsModel model;
+
+    // adapterA describes first and, uncontested, claims device 1.
+    model.updateAdapterFromDescribe("adapterA", makeAdapterDescribeWithDefaultDevice("adapterA", 1));
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterA"));
+
+    // adapterB describes and saves an explicit stored config also declaring device 1
+    // (setAdapterCurrentConfig() itself does not reconcile, so ownership doesn't move yet).
+    model.updateAdapterFromDescribe("adapterB", makeAdapterDescribe("adapterB"));
+    QJsonObject devB;
+    devB["id"] = 1;
+    QJsonObject configB;
+    configB["general"] = QJsonObject();
+    configB["connections"] = QJsonArray();
+    configB["devices"] = QJsonArray{ devB };
+    model.setAdapterCurrentConfig("adapterB", configB);
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterA"));
+
+    QSignalSpy spy(&model, &SettingsModel::deviceListChanged);
+
+    // adapterA reconnects and redescribes, re-running reconciliation: adapterB's stored
+    // config now wins the tie over adapterA's still-untouched defaults. Device 1 already
+    // existed in the model, so addDevice() alone won't emit — reconciliation must emit
+    // deviceListChanged() itself when it silently reassigns an already-known device's owner.
+    model.updateAdapterFromDescribe("adapterA", makeAdapterDescribeWithDefaultDevice("adapterA", 1));
+
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterB"));
+    QCOMPARE(spy.count(), 1);
 }
 
 QTEST_MAIN(TestAdapterDeviceSettings)

--- a/tests/dialogs/tst_adapterdevicesettings.cpp
+++ b/tests/dialogs/tst_adapterdevicesettings.cpp
@@ -723,4 +723,71 @@ void TestAdapterDeviceSettings::existingDeviceAdapterIdMatchesConfigOnOpen()
     QCOMPARE(model.deviceSettings(2)->adapterId(), QStringLiteral("adapterB"));
 }
 
+void TestAdapterDeviceSettings::sharedDefaultDeviceIdReconciledOnDescribeWithoutOpeningDialog()
+{
+    SettingsModel model;
+
+    auto makeDescribeWithDefault = [](const QString& name) {
+        QJsonObject describe = makeAdapterDescribe(name);
+        QJsonObject defaultDevice;
+        defaultDevice["id"] = 1;
+        QJsonObject defaults;
+        defaults["devices"] = QJsonArray{ defaultDevice };
+        defaults["connections"] = QJsonArray();
+        defaults["general"] = QJsonObject();
+        describe["defaults"] = defaults;
+        return describe;
+    };
+
+    // No AdapterDeviceSettings is constructed here: reconciliation must happen as soon as
+    // adapters describe, not only when the user opens Settings.
+    model.updateAdapterFromDescribe("adapterA", makeDescribeWithDefault("adapterA"));
+    model.updateAdapterFromDescribe("adapterB", makeDescribeWithDefault("adapterB"));
+
+    QCOMPARE(model.deviceList().size(), 1);
+    QVERIFY(model.hasDevice(1));
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterA"));
+}
+
+void TestAdapterDeviceSettings::explicitDeviceAssignmentSurvivesLaterAdapterRedescribe()
+{
+    SettingsModel model;
+
+    auto makeDescribeWithDefault = [](const QString& name) {
+        QJsonObject describe = makeAdapterDescribe(name);
+        QJsonObject defaultDevice;
+        defaultDevice["id"] = 1;
+        QJsonObject defaults;
+        defaults["devices"] = QJsonArray{ defaultDevice };
+        defaults["connections"] = QJsonArray();
+        defaults["general"] = QJsonObject();
+        describe["defaults"] = defaults;
+        return describe;
+    };
+
+    // Both adapters declare device 1 in their raw, never-configured defaults.
+    model.updateAdapterFromDescribe("adapterA", makeDescribeWithDefault("adapterA"));
+    model.updateAdapterFromDescribe("adapterB", makeDescribeWithDefault("adapterB"));
+
+    // adapterA wins the shared ID while neither adapter has an explicit config yet.
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterA"));
+
+    // The user explicitly (re)assigns device 1 to adapterB and saves it: adapterB now has a
+    // real, stored config declaring device 1, while adapterA's config is still untouched defaults.
+    QJsonObject dev;
+    dev["id"] = 1;
+    QJsonObject config;
+    config["general"] = QJsonObject();
+    config["connections"] = QJsonArray();
+    config["devices"] = QJsonArray{ dev };
+    model.setAdapterCurrentConfig("adapterB", config);
+    model.deviceSettings(1)->setAdapterId("adapterB");
+
+    // adapterA reconnects and redescribes; its raw defaults still declare device 1, but the
+    // explicit assignment to adapterB must survive rather than be silently reclaimed by adapterA.
+    model.updateAdapterFromDescribe("adapterA", makeDescribeWithDefault("adapterA"));
+
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("adapterB"));
+}
+
 QTEST_MAIN(TestAdapterDeviceSettings)

--- a/tests/dialogs/tst_adapterdevicesettings.h
+++ b/tests/dialogs/tst_adapterdevicesettings.h
@@ -32,6 +32,8 @@ private slots:
     void acceptValuesClearsDevicesForEmptiedAdapter();
     void twoAdaptersWithSameDefaultDeviceIdShowsSingleTab();
     void existingDeviceAdapterIdMatchesConfigOnOpen();
+    void sharedDefaultDeviceIdReconciledOnDescribeWithoutOpeningDialog();
+    void explicitDeviceAssignmentSurvivesLaterAdapterRedescribe();
 #if 0
     void editingDeviceIdInSchemaFormUpdatesCorrectModelDevice();
 #endif

--- a/tests/dialogs/tst_adapterdevicesettings.h
+++ b/tests/dialogs/tst_adapterdevicesettings.h
@@ -34,6 +34,8 @@ private slots:
     void existingDeviceAdapterIdMatchesConfigOnOpen();
     void sharedDefaultDeviceIdReconciledOnDescribeWithoutOpeningDialog();
     void explicitDeviceAssignmentSurvivesLaterAdapterRedescribe();
+    void dialogBuildsTabFromReconciledOwnerNotFirstAdapter();
+    void reassigningExistingDeviceOwnerEmitsDeviceListChanged();
 #if 0
     void editingDeviceIdInSchemaFormUpdatesCorrectModelDevice();
 #endif

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -289,34 +289,30 @@ void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
 {
     addSimAdapter();
 
+    /* QWidgetAction::setDefaultWidget() takes ownership of the widget: its destructor
+     * unconditionally deletes it. Hand it off and clear the fixture pointer up front - before
+     * the QVERIFY below, which returns early on failure - so cleanup()'s `delete _pRegWidget`
+     * can never race with the action's destructor deleting the same object. */
+    AddRegisterWidget* pWidget = _pRegWidget;
+    _pRegWidget = nullptr;
+
     QMenu menu;
     auto* action = new QWidgetAction(&menu);
-    action->setDefaultWidget(_pRegWidget);
+    action->setDefaultWidget(pWidget);
+    /* Reparents pWidget into `menu` synchronously (QMenu::actionEvent). */
     menu.addAction(action);
 
-    /* Showing forces the menu to adopt the widget and size itself, as happens
-     * the first time RegisterDialog's btnAdd popup is opened. */
+    /* Showing lays out the menu for the first time, sizing it to fit the modbus schema (4 fields). */
     menu.show();
     const int heightWithFourFields = menu.height();
 
     /* Switch, while the popup is open, from modbus (4 fields) to sim (1 field) */
-    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
-
-    QVERIFY(menu.height() < heightWithFourFields);
+    pWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    const int heightWithOneField = menu.height();
 
     menu.hide();
 
-    /* QWidgetAction::setDefaultWidget() reparents the widget into whichever container
-     * displays it, but ~QWidgetAction() unconditionally deletes the default widget too.
-     * If the widget were still a child of `menu` when `menu` is destroyed below, both
-     * menu's own child cleanup and the action's destructor would try to delete it,
-     * causing a double free. releaseWidget() detaches it (parent -> nullptr) first, so
-     * only the action's destructor deletes it. */
-    action->releaseWidget(_pRegWidget);
-
-    /* Ownership remains with `action` (destroyed below with `menu`); avoid a double
-     * delete in cleanup(). */
-    _pRegWidget = nullptr;
+    QVERIFY(heightWithOneField < heightWithFourFields);
 }
 
 void TestAddRegisterWidget::buildExpressionRoutedToSelectedAdapter()

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -315,6 +315,40 @@ void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
     QVERIFY(heightWithOneField < heightWithFourFields);
 }
 
+void TestAddRegisterWidget::switchToLargerSchemaWhileMenuOpenShowsAllFields()
+{
+    addSimAdapter();
+
+    /* See switchAdapterWhileMenuOpenResizesPopup for why ownership is handed off up front. */
+    AddRegisterWidget* pWidget = _pRegWidget;
+    _pRegWidget = nullptr;
+
+    QMenu menu;
+    auto* action = new QWidgetAction(&menu);
+    action->setDefaultWidget(pWidget);
+    menu.addAction(action);
+
+    /* Start from sim (1 field) so the switch below grows the form. */
+    pWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    menu.show();
+
+    /* Switch, while the popup is open, from sim (1 field) to modbus (4 fields). Newly created
+     * field widgets used to stay hidden until the next event loop turn, which made QFormLayout
+     * treat them as zero-sized and left the popup too small to show the rebuilt form - see
+     * SchemaFormWidget::addFieldRow(). Check the state right after the switch, with no event
+     * loop turn in between, so a regression here fails immediately instead of only intermittently. */
+    pWidget->_pUi->cmbAdapter->setCurrentIndex(0);
+
+    QLayout* addressFormLayout = pWidget->_pAddressForm->layout();
+    QCOMPARE(addressFormLayout->count(), 8); /* modbus schema: 4 fields x (label + field) */
+    for (int i = 0; i < addressFormLayout->count(); ++i)
+    {
+        QVERIFY(addressFormLayout->itemAt(i)->widget()->isVisible());
+    }
+
+    menu.hide();
+}
+
 void TestAddRegisterWidget::buildExpressionRoutedToSelectedAdapter()
 {
     _settingsModel.addDevice(2);

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -355,6 +355,14 @@ void TestAddRegisterWidget::switchToLargerSchemaWhileMenuOpenShowsAllFields()
         QVERIFY(addressFormLayout->itemAt(i)->widget()->isVisible());
     }
 
+    /* isVisible() alone doesn't catch a too-small popup: a widget stays visible even when its
+     * geometry falls outside the QMenu window bounds. Map the last field's bottom edge into the
+     * menu's coordinate space to confirm resizeContainingMenu() actually grew the popup enough to
+     * show it, rather than leaving it clipped by the window edge. */
+    QWidget* pLastField = addressFormLayout->itemAt(addressFormLayout->count() - 1)->widget();
+    const int lastFieldBottomInMenu = pLastField->mapTo(&menu, QPoint(0, pLastField->height())).y();
+    QVERIFY(lastFieldBottomInMenu <= menu.height());
+
     menu.hide();
 }
 

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -8,8 +8,10 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QMenu>
 #include <QSignalSpy>
 #include <QTest>
+#include <QWidgetAction>
 
 QJsonObject TestAddRegisterWidget::buildAddressSchema()
 {
@@ -281,6 +283,30 @@ void TestAddRegisterWidget::switchAdapterRebuildsSchema()
     QVERIFY(_pRegWidget->_addressSchema["properties"].toObject().contains(QStringLiteral("channel")));
     QCOMPARE(_pRegWidget->_dataPointDefaults["channel"].toInt(), 3);
     QCOMPARE(_pRegWidget->_pAddressForm->values()["channel"].toInt(), 3);
+}
+
+void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
+{
+    addSimAdapter();
+
+    QMenu menu;
+    auto* action = new QWidgetAction(&menu);
+    action->setDefaultWidget(_pRegWidget);
+    menu.addAction(action);
+
+    /* Showing forces the menu to adopt the widget and size itself, as happens
+     * the first time RegisterDialog's btnAdd popup is opened. */
+    menu.show();
+    const int heightWithFourFields = menu.height();
+
+    /* Switch, while the popup is open, from modbus (4 fields) to sim (1 field) */
+    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+
+    QVERIFY(menu.height() < heightWithFourFields);
+
+    menu.hide();
+    /* Ownership of _pRegWidget transferred to menu when shown; avoid double delete in cleanup() */
+    _pRegWidget = nullptr;
 }
 
 void TestAddRegisterWidget::buildExpressionRoutedToSelectedAdapter()

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -40,19 +40,10 @@ QJsonObject TestAddRegisterWidget::buildAddressSchema()
                   QStringLiteral("signed 32-bit"), QStringLiteral("32-bit float") };
     dataTypeSchema["default"] = QStringLiteral("16b");
 
-    QJsonObject deviceIdSchema;
-    deviceIdSchema["type"] = QStringLiteral("integer");
-    deviceIdSchema["title"] = QStringLiteral("Device ID");
-    deviceIdSchema["minimum"] = 1;
-    /* Tests inject enum values directly via setSchema; the constructor patches these from SettingsModel */
-    deviceIdSchema["enum"] = QJsonArray{ 1, 2 };
-    deviceIdSchema["x-enumLabels"] = QJsonArray{ QStringLiteral("Device 1"), QStringLiteral("Device 2") };
-
     QJsonObject properties;
     properties["objectType"] = objectTypeSchema;
     properties["address"] = addressField;
     properties["dataType"] = dataTypeSchema;
-    properties["deviceId"] = deviceIdSchema;
 
     QJsonObject schema;
     schema["type"] = QStringLiteral("object");
@@ -124,9 +115,10 @@ void TestAddRegisterWidget::cleanup()
 }
 
 /*!
- * \brief Register a second ("sim") adapter and rebuild the widget with both adapters.
+ * \brief Register a second ("sim") adapter with a device bound to it, and rebuild the widget.
+ * \return The id of the newly created device.
  */
-void TestAddRegisterWidget::addSimAdapter()
+deviceId_t TestAddRegisterWidget::addSimAdapter()
 {
     _settingsModel.setAdapterDataPointSchema("sim", buildSimRegisterSchema());
 
@@ -137,8 +129,21 @@ void TestAddRegisterWidget::addSimAdapter()
     _pMockSimAdapterManager = new MockAdapterManager(&_settingsModel, QStringLiteral("sim"));
     _pMockHub->addManager(QStringLiteral("sim"), _pMockSimAdapterManager);
 
+    const deviceId_t simDeviceId = _settingsModel.addNewDevice();
+    _settingsModel.deviceSettings(simDeviceId)->setAdapterId(QStringLiteral("sim"));
+
     delete _pRegWidget;
     _pRegWidget = new AddRegisterWidget(&_settingsModel, _pMockHub);
+
+    return simDeviceId;
+}
+
+/*!
+ * \brief Returns the cmbDevice index whose item data matches the given device id.
+ */
+int TestAddRegisterWidget::indexForDevice(deviceId_t devId) const
+{
+    return _pRegWidget->_pUi->cmbDevice->findData(QVariant(devId));
 }
 
 void TestAddRegisterWidget::registerDefault()
@@ -149,8 +154,7 @@ void TestAddRegisterWidget::registerDefault()
     _pRegWidget->_pAddressForm->setSchema(
       buildAddressSchema(), QJsonObject{ { QStringLiteral("objectType"), QStringLiteral("holding register") },
                                          { QStringLiteral("address"), 100 },
-                                         { QStringLiteral("dataType"), QStringLiteral("16b") },
-                                         { QStringLiteral("deviceId"), 1 } });
+                                         { QStringLiteral("dataType"), QStringLiteral("16b") } });
 
     GraphData graphData;
     addRegister(graphData, QStringLiteral("${h100}"));
@@ -195,16 +199,21 @@ void TestAddRegisterWidget::registerObjectType()
 
 void TestAddRegisterWidget::registerDevice()
 {
+    const deviceId_t secondDeviceId = _settingsModel.addNewDevice();
+    _settingsModel.deviceSettings(secondDeviceId)->setAdapterId(QStringLiteral("modbus"));
+    delete _pRegWidget;
+    _pRegWidget = new AddRegisterWidget(&_settingsModel, _pMockHub);
+
+    _pRegWidget->_pUi->cmbDevice->setCurrentIndex(indexForDevice(secondDeviceId));
     _pRegWidget->_pAddressForm->setSchema(
       buildAddressSchema(), QJsonObject{ { QStringLiteral("objectType"), QStringLiteral("holding register") },
-                                         { QStringLiteral("address"), 0 },
-                                         { QStringLiteral("deviceId"), 2 } });
+                                         { QStringLiteral("address"), 0 } });
 
     GraphData graphData;
     addRegister(graphData, QStringLiteral("${h0@2}"));
 
     QCOMPARE(graphData.expression(), QStringLiteral("${h0@2}"));
-    QCOMPARE(_pMockAdapterManager->buildCalls[0].deviceId, static_cast<deviceId_t>(2));
+    QCOMPARE(_pMockAdapterManager->buildCalls[0].deviceId, secondDeviceId);
 }
 
 void TestAddRegisterWidget::registerValueAxis()
@@ -255,39 +264,39 @@ void TestAddRegisterWidget::buildExpressionDoesNotInterfereWithOtherConnections(
     QCOMPARE(secondaryReceiveCount, 2);
 }
 
-void TestAddRegisterWidget::adapterComboHiddenWithSingleAdapter()
+void TestAddRegisterWidget::deviceComboHiddenWithSingleDevice()
 {
-    QVERIFY(_pRegWidget->_pUi->cmbAdapter->isHidden());
+    QVERIFY(_pRegWidget->_pUi->cmbDevice->isHidden());
 }
 
-void TestAddRegisterWidget::adapterComboListsAdapters()
+void TestAddRegisterWidget::deviceComboListsDevices()
 {
-    addSimAdapter();
+    const deviceId_t simDeviceId = addSimAdapter();
 
-    QVERIFY(!_pRegWidget->_pUi->cmbAdapter->isHidden());
-    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->count(), 2);
+    QVERIFY(!_pRegWidget->_pUi->cmbDevice->isHidden());
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->count(), 2);
 
-    /* Adapter IDs are listed alphabetically; label falls back to the ID without describe data */
-    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemText(0), QStringLiteral("modbus"));
-    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemData(0).toString(), QStringLiteral("modbus"));
-    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemText(1), QStringLiteral("Simulator"));
-    QCOMPARE(_pRegWidget->_pUi->cmbAdapter->itemData(1).toString(), QStringLiteral("sim"));
+    /* Devices are listed in ascending id order; label defaults to "Device N" */
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->itemText(0), QStringLiteral("Device 1"));
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->itemData(0).value<deviceId_t>(), Device::cFirstDeviceId);
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->itemText(1), QString("Device %1").arg(simDeviceId));
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->itemData(1).value<deviceId_t>(), simDeviceId);
 }
 
-void TestAddRegisterWidget::switchAdapterRebuildsSchema()
+void TestAddRegisterWidget::switchDeviceRebuildsSchema()
 {
-    addSimAdapter();
+    const deviceId_t simDeviceId = addSimAdapter();
 
-    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    _pRegWidget->_pUi->cmbDevice->setCurrentIndex(indexForDevice(simDeviceId));
 
     QVERIFY(_pRegWidget->_addressSchema["properties"].toObject().contains(QStringLiteral("channel")));
     QCOMPARE(_pRegWidget->_dataPointDefaults["channel"].toInt(), 3);
     QCOMPARE(_pRegWidget->_pAddressForm->values()["channel"].toInt(), 3);
 }
 
-void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
+void TestAddRegisterWidget::switchDeviceWhileMenuOpenResizesPopup()
 {
-    addSimAdapter();
+    const deviceId_t simDeviceId = addSimAdapter();
 
     /* QWidgetAction::setDefaultWidget() takes ownership of the widget: its destructor
      * unconditionally deletes it. Hand it off and clear the fixture pointer up front - before
@@ -302,24 +311,24 @@ void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
     /* Reparents pWidget into `menu` synchronously (QMenu::actionEvent). */
     menu.addAction(action);
 
-    /* Showing lays out the menu for the first time, sizing it to fit the modbus schema (4 fields). */
+    /* Showing lays out the menu for the first time, sizing it to fit the modbus schema (3 fields). */
     menu.show();
-    const int heightWithFourFields = menu.height();
+    const int heightWithThreeFields = menu.height();
 
-    /* Switch, while the popup is open, from modbus (4 fields) to sim (1 field) */
-    pWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    /* Switch, while the popup is open, from modbus (3 fields) to sim (1 field) */
+    pWidget->_pUi->cmbDevice->setCurrentIndex(pWidget->_pUi->cmbDevice->findData(QVariant(simDeviceId)));
     const int heightWithOneField = menu.height();
 
     menu.hide();
 
-    QVERIFY(heightWithOneField < heightWithFourFields);
+    QVERIFY(heightWithOneField < heightWithThreeFields);
 }
 
 void TestAddRegisterWidget::switchToLargerSchemaWhileMenuOpenShowsAllFields()
 {
-    addSimAdapter();
+    const deviceId_t simDeviceId = addSimAdapter();
 
-    /* See switchAdapterWhileMenuOpenResizesPopup for why ownership is handed off up front. */
+    /* See switchDeviceWhileMenuOpenResizesPopup for why ownership is handed off up front. */
     AddRegisterWidget* pWidget = _pRegWidget;
     _pRegWidget = nullptr;
 
@@ -329,18 +338,18 @@ void TestAddRegisterWidget::switchToLargerSchemaWhileMenuOpenShowsAllFields()
     menu.addAction(action);
 
     /* Start from sim (1 field) so the switch below grows the form. */
-    pWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    pWidget->_pUi->cmbDevice->setCurrentIndex(pWidget->_pUi->cmbDevice->findData(QVariant(simDeviceId)));
     menu.show();
 
-    /* Switch, while the popup is open, from sim (1 field) to modbus (4 fields). Newly created
+    /* Switch, while the popup is open, from sim (1 field) to modbus (3 fields). Newly created
      * field widgets used to stay hidden until the next event loop turn, which made QFormLayout
      * treat them as zero-sized and left the popup too small to show the rebuilt form - see
      * SchemaFormWidget::addFieldRow(). Check the state right after the switch, with no event
      * loop turn in between, so a regression here fails immediately instead of only intermittently. */
-    pWidget->_pUi->cmbAdapter->setCurrentIndex(0);
+    pWidget->_pUi->cmbDevice->setCurrentIndex(pWidget->_pUi->cmbDevice->findData(QVariant(Device::cFirstDeviceId)));
 
     QLayout* addressFormLayout = pWidget->_pAddressForm->layout();
-    QCOMPARE(addressFormLayout->count(), 8); /* modbus schema: 4 fields x (label + field) */
+    QCOMPARE(addressFormLayout->count(), 6); /* modbus schema: 3 fields x (label + field) */
     for (int i = 0; i < addressFormLayout->count(); ++i)
     {
         QVERIFY(addressFormLayout->itemAt(i)->widget()->isVisible());
@@ -349,36 +358,38 @@ void TestAddRegisterWidget::switchToLargerSchemaWhileMenuOpenShowsAllFields()
     menu.hide();
 }
 
-void TestAddRegisterWidget::buildExpressionRoutedToSelectedAdapter()
+void TestAddRegisterWidget::buildExpressionRoutedToSelectedDevice()
 {
-    _settingsModel.addDevice(2);
-    _settingsModel.deviceSettings(2)->setAdapterId("sim");
+    const deviceId_t simDeviceId = addSimAdapter();
 
-    addSimAdapter();
-
-    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    _pRegWidget->_pUi->cmbDevice->setCurrentIndex(indexForDevice(simDeviceId));
 
     QSignalSpy spy(_pRegWidget, &AddRegisterWidget::graphDataConfigured);
     clickAdd();
 
     QCOMPARE(_pMockSimAdapterManager->buildCalls.size(), 1);
     QCOMPARE(_pMockAdapterManager->buildCalls.size(), 0);
+    QCOMPARE(_pMockSimAdapterManager->buildCalls[0].deviceId, simDeviceId);
 
     _pMockSimAdapterManager->injectBuildExpressionResult(QStringLiteral("${c3}"));
     QCOMPARE(spy.count(), 1);
 }
 
-void TestAddRegisterWidget::btnAddDisabledWhenSelectedAdapterHasNoDevices()
+void TestAddRegisterWidget::btnAddDisabledWhenSelectedDeviceAdapterUnavailable()
 {
-    addSimAdapter();
+    /* Bind a second device to an adapter id that is never registered in the mock hub */
+    const deviceId_t unavailableDeviceId = _settingsModel.addNewDevice();
+    _settingsModel.deviceSettings(unavailableDeviceId)->setAdapterId(QStringLiteral("unavailable"));
+    delete _pRegWidget;
+    _pRegWidget = new AddRegisterWidget(&_settingsModel, _pMockHub);
 
-    /* Only device 1 exists and it belongs to the modbus adapter */
+    /* Only device 1 is initially selected and it belongs to the modbus adapter */
     QVERIFY(_pRegWidget->_pUi->btnAdd->isEnabled());
 
-    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(1);
+    _pRegWidget->_pUi->cmbDevice->setCurrentIndex(indexForDevice(unavailableDeviceId));
     QVERIFY(!_pRegWidget->_pUi->btnAdd->isEnabled());
 
-    _pRegWidget->_pUi->cmbAdapter->setCurrentIndex(0);
+    _pRegWidget->_pUi->cmbDevice->setCurrentIndex(indexForDevice(Device::cFirstDeviceId));
     QVERIFY(_pRegWidget->_pUi->btnAdd->isEnabled());
 }
 

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -305,7 +305,17 @@ void TestAddRegisterWidget::switchAdapterWhileMenuOpenResizesPopup()
     QVERIFY(menu.height() < heightWithFourFields);
 
     menu.hide();
-    /* Ownership of _pRegWidget transferred to menu when shown; avoid double delete in cleanup() */
+
+    /* QWidgetAction::setDefaultWidget() reparents the widget into whichever container
+     * displays it, but ~QWidgetAction() unconditionally deletes the default widget too.
+     * If the widget were still a child of `menu` when `menu` is destroyed below, both
+     * menu's own child cleanup and the action's destructor would try to delete it,
+     * causing a double free. releaseWidget() detaches it (parent -> nullptr) first, so
+     * only the action's destructor deletes it. */
+    action->releaseWidget(_pRegWidget);
+
+    /* Ownership remains with `action` (destroyed below with `menu`); avoid a double
+     * delete in cleanup(). */
     _pRegWidget = nullptr;
 }
 

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -264,9 +264,9 @@ void TestAddRegisterWidget::buildExpressionDoesNotInterfereWithOtherConnections(
     QCOMPARE(secondaryReceiveCount, 2);
 }
 
-void TestAddRegisterWidget::deviceComboHiddenWithSingleDevice()
+void TestAddRegisterWidget::deviceComboVisibleWithSingleDevice()
 {
-    QVERIFY(_pRegWidget->_pUi->cmbDevice->isHidden());
+    QVERIFY(!_pRegWidget->_pUi->cmbDevice->isHidden());
 }
 
 void TestAddRegisterWidget::deviceComboListsDevices()

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -71,7 +71,7 @@ private slots:
     void buildExpressionEmptyResponseIgnored();
     void buildExpressionDoesNotInterfereWithOtherConnections();
 
-    void deviceComboHiddenWithSingleDevice();
+    void deviceComboVisibleWithSingleDevice();
     void deviceComboListsDevices();
     void switchDeviceRebuildsSchema();
     void switchDeviceWhileMenuOpenResizesPopup();

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -75,6 +75,7 @@ private slots:
     void adapterComboListsAdapters();
     void switchAdapterRebuildsSchema();
     void switchAdapterWhileMenuOpenResizesPopup();
+    void switchToLargerSchemaWhileMenuOpenShowsAllFields();
     void buildExpressionRoutedToSelectedAdapter();
     void btnAddDisabledWhenSelectedAdapterHasNoDevices();
 

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -71,18 +71,19 @@ private slots:
     void buildExpressionEmptyResponseIgnored();
     void buildExpressionDoesNotInterfereWithOtherConnections();
 
-    void adapterComboHiddenWithSingleAdapter();
-    void adapterComboListsAdapters();
-    void switchAdapterRebuildsSchema();
-    void switchAdapterWhileMenuOpenResizesPopup();
+    void deviceComboHiddenWithSingleDevice();
+    void deviceComboListsDevices();
+    void switchDeviceRebuildsSchema();
+    void switchDeviceWhileMenuOpenResizesPopup();
     void switchToLargerSchemaWhileMenuOpenShowsAllFields();
-    void buildExpressionRoutedToSelectedAdapter();
-    void btnAddDisabledWhenSelectedAdapterHasNoDevices();
+    void buildExpressionRoutedToSelectedDevice();
+    void btnAddDisabledWhenSelectedDeviceAdapterUnavailable();
 
 private:
     void clickAdd();
     void addRegister(GraphData& graphData, const QString& expression);
-    void addSimAdapter();
+    deviceId_t addSimAdapter();
+    int indexForDevice(deviceId_t devId) const;
     static QJsonObject buildAddressSchema();
     static QJsonObject buildTestRegisterSchema();
     static QJsonObject buildSimRegisterSchema();

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -74,6 +74,7 @@ private slots:
     void adapterComboHiddenWithSingleAdapter();
     void adapterComboListsAdapters();
     void switchAdapterRebuildsSchema();
+    void switchAdapterWhileMenuOpenResizesPopup();
     void buildExpressionRoutedToSelectedAdapter();
     void btnAddDisabledWhenSelectedAdapterHasNoDevices();
 

--- a/tests/models/tst_adapterdata.cpp
+++ b/tests/models/tst_adapterdata.cpp
@@ -270,35 +270,6 @@ void TestAdapterData::deviceSetAndGetAdapterId()
     QCOMPARE(device.adapterId(), QStringLiteral("custom"));
 }
 
-void TestAdapterData::deviceListForAdapterFiltersCorrectly()
-{
-    SettingsModel model;
-
-    /* Default device 1 is modbus; add two more */
-    const deviceId_t idTwo = model.addNewDevice();
-    const deviceId_t idThree = model.addNewDevice();
-
-    model.deviceSettings(Device::cFirstDeviceId)->setAdapterId("modbus");
-    model.deviceSettings(idTwo)->setAdapterId("custom");
-    model.deviceSettings(idThree)->setAdapterId("modbus");
-
-    const QList<deviceId_t> modbusList = model.deviceListForAdapter("modbus");
-    QCOMPARE(modbusList.size(), 2);
-    QVERIFY(modbusList.contains(Device::cFirstDeviceId));
-    QVERIFY(modbusList.contains(idThree));
-
-    const QList<deviceId_t> customList = model.deviceListForAdapter("custom");
-    QCOMPARE(customList.size(), 1);
-    QVERIFY(customList.contains(idTwo));
-}
-
-void TestAdapterData::deviceListForAdapterUnknownReturnsEmpty()
-{
-    SettingsModel model;
-
-    QVERIFY(model.deviceListForAdapter("opcua").isEmpty());
-}
-
 /*!
  * \brief maxDevicesFromSchema returns INT_MAX when the schema has no devices.maxItems.
  */

--- a/tests/models/tst_adapterdata.h
+++ b/tests/models/tst_adapterdata.h
@@ -28,8 +28,6 @@ private slots:
 
     void deviceAdapterIdDefaultsToModbus();
     void deviceSetAndGetAdapterId();
-    void deviceListForAdapterFiltersCorrectly();
-    void deviceListForAdapterUnknownReturnsEmpty();
 
     void maxDevicesFromSchemaReturnsIntMaxWhenAbsent();
     void maxDevicesFromSchemaReturnsValue();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Register creation now selects configured devices directly, with protocol details shown automatically.
  - Forms update dynamically when switching devices, including address fields and available options.
  - Add controls are disabled when the selected device is unavailable.
- **Bug Fixes**
  - Prevented duplicate device tabs when devices are associated with multiple adapters.
  - Device ownership is reconciled consistently, preserving explicit assignments and updating affected configurations.
  - Register requests are routed to the selected device reliably.
- **Tests**
  - Added coverage for device selection, ownership reconciliation, unavailable adapters and dynamic form updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->