### PR TITLE
Combine generic and adapter-specific expression help text

### DIFF
--- a/adapters/modbus-adapter-spec.md
+++ b/adapters/modbus-adapter-spec.md
@@ -447,11 +447,12 @@ and unsigned 16-bit.
 **Result:**
 
 ```json
-{ "helpText": "<html>...</html>" }
+{ "helpText": "<p>...</p>" }
 ```
 
-The returned HTML documents the Modbus register expression syntax defined under [`adapter.start`](#adapterstart)
-(address prefixes, optional `deviceId` and `type`, and the list of type values).
+`helpText` is an HTML fragment (no `<html>`/`<body>` wrapper) documenting the Modbus register expression syntax
+defined under [`adapter.start`](#adapterstart) (address prefixes, optional `deviceId` and `type`, and the list of
+type values).
 
 ---
 

--- a/docs/technical/adapter-protocol-spec.md
+++ b/docs/technical/adapter-protocol-spec.md
@@ -379,21 +379,23 @@ device, so expression syntax stays entirely within the adapter.
 
 ### `adapter.expressionHelp`
 
-Returns static HTML help text describing the data point expression syntax. The
-core displays this in the expression editor info panel so the explanation stays
-co-located with the adapter that owns the syntax.
+Returns a static HTML fragment describing the adapter-specific data point
+addressing syntax. The core prepends its own generic expression syntax
+explanation (operators, number formats) and displays the combined HTML in the
+expression editor info panel, so the adapter only needs to document the
+syntax it owns.
 
 **Params:** `{}` (none required)
 
 **Result:**
 
 ```json
-{ "helpText": "<html>...</html>" }
+{ "helpText": "<p>...</p>" }
 ```
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `helpText` | string | HTML string suitable for display in a rich-text label |
+| `helpText` | string | HTML fragment (no `<html>`/`<body>` wrapper) suitable for embedding in a rich-text label |
 
 ---
 

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -12,17 +12,22 @@ using State = ResultState::State;
 
 namespace {
 
-/* Generic expression syntax info, common to every adapter. Adapter-specific addressing
- * syntax is appended by handleExpressionHelpResult(). */
-const QString cGenericExpressionInfoHtml = QStringLiteral(
-    "<p><span style=\" font-size:12pt; font-weight:600;\">Expression Information</span></p>"
-    "<p>The most common binary operators are supported (|, &amp;, &lt;&lt;, &gt;&gt;). "
-    "The basic arithmetic operators are also supported (+, -, *, /, %, ^). "
-    "Hexadecimal numbers can be represented with the &quot;0x&quot; prefix. "
-    "Binary are represented with &quot;0b&quot; prefix. "
-    "Floating point number are also supported. "
-    "Both a decimal point as comma can be used. "
-    "The first encountered character is used as floating point separator.</p>");
+/*!
+ * \brief Generic expression syntax info, common to every adapter.
+ *
+ * Adapter-specific addressing syntax is appended by handleExpressionHelpResult().
+ */
+QString genericExpressionInfoHtml()
+{
+    return QStringLiteral("<p><span style=\" font-size:12pt; font-weight:600;\">Expression Information</span></p>"
+                          "<p>The most common binary operators are supported (|, &amp;, &lt;&lt;, &gt;&gt;). "
+                          "The basic arithmetic operators are also supported (+, -, *, /, %, ^). "
+                          "Hexadecimal numbers can be represented with the &quot;0x&quot; prefix. "
+                          "Binary numbers are represented with &quot;0b&quot; prefix. "
+                          "Floating point number are also supported. "
+                          "Both a decimal point as comma can be used. "
+                          "The first encountered character is used as floating point separator.</p>");
+}
 
 } // namespace
 
@@ -168,7 +173,7 @@ void ExpressionsDialog::handleAccept()
 void ExpressionsDialog::handleExpressionHelpResult(const QString& helpText)
 {
     const QString fullHelpHtml =
-      QStringLiteral("<html><head/><body>") + cGenericExpressionInfoHtml + helpText + QStringLiteral("</body></html>");
+      QStringLiteral("<html><head/><body>") + genericExpressionInfoHtml() + helpText + QStringLiteral("</body></html>");
     _pUi->lblInfo->setText(fullHelpHtml);
 }
 
@@ -233,8 +238,8 @@ void ExpressionsDialog::requestHelpForAdapter(const QString& adapterId)
         return;
     }
 
-    connect(_pHelpManager, &AdapterManager::expressionHelpResult, this,
-            &ExpressionsDialog::handleExpressionHelpResult, Qt::SingleShotConnection);
+    connect(_pHelpManager, &AdapterManager::expressionHelpResult, this, &ExpressionsDialog::handleExpressionHelpResult,
+            Qt::SingleShotConnection);
     _pHelpManager->requestExpressionHelp();
 }
 

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -10,6 +10,22 @@
 
 using State = ResultState::State;
 
+namespace {
+
+/* Generic expression syntax info, common to every adapter. Adapter-specific addressing
+ * syntax is appended by handleExpressionHelpResult(). */
+const QString cGenericExpressionInfoHtml = QStringLiteral(
+    "<p><span style=\" font-size:12pt; font-weight:600;\">Expression Information</span></p>"
+    "<p>The most common binary operators are supported (|, &amp;, &lt;&lt;, &gt;&gt;). "
+    "The basic arithmetic operators are also supported (+, -, *, /, %, ^). "
+    "Hexadecimal numbers can be represented with the &quot;0x&quot; prefix. "
+    "Binary are represented with &quot;0b&quot; prefix. "
+    "Floating point number are also supported. "
+    "Both a decimal point as comma can be used. "
+    "The first encountered character is used as floating point separator.</p>");
+
+} // namespace
+
 ExpressionsDialog::ExpressionsDialog(GraphDataModel* pGraphDataModel,
                                      GraphIdx idx,
                                      AdapterHub* pAdapterHub,
@@ -151,7 +167,9 @@ void ExpressionsDialog::handleAccept()
 
 void ExpressionsDialog::handleExpressionHelpResult(const QString& helpText)
 {
-    _pUi->lblInfo->setText(helpText);
+    const QString fullHelpHtml =
+      QStringLiteral("<html><head/><body>") + cGenericExpressionInfoHtml + helpText + QStringLiteral("</body></html>");
+    _pUi->lblInfo->setText(fullHelpHtml);
 }
 
 /*!

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -23,10 +23,10 @@ QString genericExpressionInfoHtml()
                           "<p>The most common binary operators are supported (|, &amp;, &lt;&lt;, &gt;&gt;). "
                           "The basic arithmetic operators are also supported (+, -, *, /, %, ^). "
                           "Hexadecimal numbers can be represented with the &quot;0x&quot; prefix. "
-                          "Binary numbers are represented with &quot;0b&quot; prefix. "
-                          "Floating point number are also supported. "
-                          "Both a decimal point as comma can be used. "
-                          "The first encountered character is used as floating point separator.</p>");
+                          "Binary numbers can be represented with the &quot;0b&quot; prefix. "
+                          "Floating point numbers are also supported. "
+                          "Both a decimal point and a comma can be used as the decimal separator. "
+                          "The first one encountered is used as the decimal separator for the whole expression.</p>");
 }
 
 } // namespace

--- a/tests/dialogs/tst_expressionsdialog.cpp
+++ b/tests/dialogs/tst_expressionsdialog.cpp
@@ -243,7 +243,7 @@ void TestExpressionsDialog::helpRoutedToSelectedAdapter()
     QVERIFY(pInfoLabel->text().contains(QStringLiteral("Expression Information")));
     QVERIFY(pInfoLabel->text().contains(QStringLiteral("Modbus help")));
     QVERIFY(pInfoLabel->text().indexOf(QStringLiteral("Expression Information")) <
-      pInfoLabel->text().indexOf(QStringLiteral("Modbus help")));
+            pInfoLabel->text().indexOf(QStringLiteral("Modbus help")));
 
     auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpAdapter");
     QVERIFY(pCombo != nullptr);

--- a/tests/dialogs/tst_expressionsdialog.cpp
+++ b/tests/dialogs/tst_expressionsdialog.cpp
@@ -236,7 +236,14 @@ void TestExpressionsDialog::helpRoutedToSelectedAdapter()
     QCOMPARE(pSimManager->helpRequestCount, 0);
 
     _pMockAdapterManager->injectExpressionHelp(QStringLiteral("Modbus help"));
-    QCOMPARE(pInfoLabel->text(), QStringLiteral("Modbus help"));
+    /* Label combines the core's generic expression info with the adapter's fragment,
+     * wrapped in a single well-formed document */
+    QVERIFY(pInfoLabel->text().startsWith(QStringLiteral("<html><head/><body>")));
+    QVERIFY(pInfoLabel->text().endsWith(QStringLiteral("</body></html>")));
+    QVERIFY(pInfoLabel->text().contains(QStringLiteral("Expression Information")));
+    QVERIFY(pInfoLabel->text().contains(QStringLiteral("Modbus help")));
+    QVERIFY(pInfoLabel->text().indexOf(QStringLiteral("Expression Information")) <
+      pInfoLabel->text().indexOf(QStringLiteral("Modbus help")));
 
     auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpAdapter");
     QVERIFY(pCombo != nullptr);
@@ -247,11 +254,13 @@ void TestExpressionsDialog::helpRoutedToSelectedAdapter()
     QCOMPARE(pInfoLabel->text(), QString());
 
     pSimManager->injectExpressionHelp(QStringLiteral("Sim help"));
-    QCOMPARE(pInfoLabel->text(), QStringLiteral("Sim help"));
+    QVERIFY(pInfoLabel->text().contains(QStringLiteral("Sim help")));
+    QVERIFY(!pInfoLabel->text().contains(QStringLiteral("Modbus help")));
 
     /* A late response from the deselected modbus adapter is ignored */
     _pMockAdapterManager->injectExpressionHelp(QStringLiteral("Stale modbus help"));
-    QCOMPARE(pInfoLabel->text(), QStringLiteral("Sim help"));
+    QVERIFY(pInfoLabel->text().contains(QStringLiteral("Sim help")));
+    QVERIFY(!pInfoLabel->text().contains(QStringLiteral("Stale modbus help")));
 }
 
 QTEST_MAIN(TestExpressionsDialog)


### PR DESCRIPTION
## Summary
Refactor the expression help system to display both generic expression syntax (operators, number formats) and adapter-specific addressing syntax in a single well-formed HTML document, rather than showing only the adapter-specific fragment.

## Changes
- **Extract generic expression info:** Move common expression syntax documentation into a module-level constant `cGenericExpressionInfoHtml` in `expressionsdialog.cpp`
- **Combine help fragments:** Update `handleExpressionHelpResult()` to prepend the generic info to the adapter-specific help text and wrap both in a complete HTML document (`<html><head/><body>...

https://claude.ai/code/session_01VtXiUN3BZAt1ds6P3DsiA2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expression help now combines general syntax guidance with adapter-specific information in a complete, readable document.
  * Adapter help is displayed consistently without requiring document-level HTML wrappers.

* **Documentation**
  * Updated adapter specifications to clarify the expected embeddable help format.

* **Bug Fixes**
  * Improved help routing to ensure the selected adapter’s content is shown without stale information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->