### PR TITLE
Modbus first

### DIFF
--- a/src/dialogs/adapterdevicesettings.cpp
+++ b/src/dialogs/adapterdevicesettings.cpp
@@ -1,5 +1,6 @@
 #include "adapterdevicesettings.h"
 
+#include "ProtocolAdapter/adapterhub.h"
 #include "customwidgets/addabletabwidget.h"
 #include "customwidgets/deviceconfigtab.h"
 #include "models/adapterdata.h"
@@ -159,7 +160,8 @@ void AdapterDeviceSettings::handleAddTab()
     {
         return;
     }
-    const QString& defaultAdapterId = adapterIds.first();
+    const QString defaultAdapterId =
+      adapterIds.contains(QString(cModbusAdapterId)) ? QString(cModbusAdapterId) : adapterIds.first();
 
     QJsonObject defaultValues;
     const QJsonArray defaultDevices =

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -368,6 +368,7 @@ void MainWindow::showFirstInstallDialogIfNeeded()
     if (!settings.contains(cFirstInstallKey))
     {
         settings.setValue(cFirstInstallKey, true);
+        settings.sync();
         showQuickStartDialog();
     }
 }

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -1,4 +1,6 @@
 #include "settingsmodel.h"
+
+#include "ProtocolAdapter/adapterhub.h"
 #include "util/scopelogging.h"
 
 #include <QJsonArray>
@@ -358,7 +360,7 @@ void SettingsModel::reconcileDevicesWithAdapters()
             unconfiguredAdapterIds.append(id);
         }
     }
-    const int modbusIndex = unconfiguredAdapterIds.indexOf(QStringLiteral("modbus"));
+    const int modbusIndex = unconfiguredAdapterIds.indexOf(QString(cModbusAdapterId));
     if (modbusIndex > 0)
     {
         unconfiguredAdapterIds.move(modbusIndex, 0);

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -314,7 +314,11 @@ void SettingsModel::updateAdapterFromDescribe(const QString& adapterId, const QJ
  * device back from its explicitly configured owner. Within each of those two groups, adapters are
  * considered in adapterIds() order, so a device ID shared by two equally-unconfigured (or two
  * equally-configured) adapters still resolves deterministically, just not meaningfully — that
- * remaining tie only matters before either adapter has been explicitly configured.
+ * remaining tie only matters before either adapter has been explicitly configured. The one
+ * exception: within the unconfigured group, "modbus" is moved to the front of that order when
+ * present, so the app's built-in initial device (Device::cFirstDeviceId, "modbus" by
+ * construction) can't be silently reassigned to another adapter that merely happens to sort
+ * alphabetically ahead of it and share the same default device ID.
  *
  * Any code that needs to know which adapter owns a device must read it back via
  * deviceSettings()/adapterIdForDevice() rather than re-deriving ownership itself (e.g. by picking
@@ -345,13 +349,21 @@ void SettingsModel::reconcileDevicesWithAdapters()
             orderedAdapterIds.append(id);
         }
     }
+
+    QStringList unconfiguredAdapterIds;
     for (const auto& id : validAdapterIds)
     {
         if (!_adapters.value(id).hasStoredConfig())
         {
-            orderedAdapterIds.append(id);
+            unconfiguredAdapterIds.append(id);
         }
     }
+    const int modbusIndex = unconfiguredAdapterIds.indexOf(QStringLiteral("modbus"));
+    if (modbusIndex > 0)
+    {
+        unconfiguredAdapterIds.move(modbusIndex, 0);
+    }
+    orderedAdapterIds.append(unconfiguredAdapterIds);
 
     QSet<deviceId_t> seenDeviceIds;
     bool ownerChanged = false;

--- a/tests/dialogs/tst_adapterdevicesettings.cpp
+++ b/tests/dialogs/tst_adapterdevicesettings.cpp
@@ -923,4 +923,43 @@ void TestAdapterDeviceSettings::invalidIdTabValuesOmitFabricatedId()
     QCOMPARE(tab->values().value("id").toInt(-2), -1);
 }
 
+void TestAdapterDeviceSettings::addTabDefaultsToModbusEvenWhenNotFirstAlphabetically()
+{
+    SettingsModel model;
+
+    // "aaaadapter" is alphabetically first, so validAdapterIds().first() would pick it over
+    // "modbus" unless handleAddTab() explicitly prefers modbus.
+    setupAdapter(model, "aaaadapter", QJsonArray());
+    setupAdapter(model, "modbus", QJsonArray());
+
+    AdapterDeviceSettings w(&model);
+    auto* tabs = w.findChild<AddableTabWidget*>();
+    QVERIFY(tabs != nullptr);
+    QCOMPARE(tabs->count(), 0);
+
+    emit tabs->addTabRequested();
+
+    QCOMPARE(tabs->count(), 1);
+    auto* tab = qobject_cast<DeviceConfigTab*>(tabs->tabContent(0));
+    QVERIFY(tab != nullptr);
+    QCOMPARE(tab->adapterId(), QStringLiteral("modbus"));
+}
+
+void TestAdapterDeviceSettings::initialDeviceReconciliationPrefersModbusOverDiscoveryOrder()
+{
+    SettingsModel model;
+
+    // SettingsModel pre-populates device 1 on "modbus" (Device's constructor default).
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("modbus"));
+
+    // "aaaadapter" also declares default device 1 in its untouched defaults and describes
+    // first (e.g. it responded before modbus during adapter discovery). Without a modbus
+    // tie-break, reconcileDevicesWithAdapters() would reassign device 1 to "aaaadapter"
+    // purely because it sorts alphabetically ahead of "modbus".
+    model.updateAdapterFromDescribe("aaaadapter", makeAdapterDescribeWithDefaultDevice("aaaadapter", 1));
+    model.updateAdapterFromDescribe("modbus", makeAdapterDescribeWithDefaultDevice("modbus", 1));
+
+    QCOMPARE(model.deviceSettings(1)->adapterId(), QStringLiteral("modbus"));
+}
+
 QTEST_MAIN(TestAdapterDeviceSettings)

--- a/tests/dialogs/tst_adapterdevicesettings.h
+++ b/tests/dialogs/tst_adapterdevicesettings.h
@@ -39,6 +39,8 @@ private slots:
     void reopenAfterAdapterSwitchPreservesDeviceOrder();
     void invalidIdTabSortsAfterValidIntMaxIdTab();
     void invalidIdTabValuesOmitFabricatedId();
+    void addTabDefaultsToModbusEvenWhenNotFirstAlphabetically();
+    void initialDeviceReconciliationPrefersModbusOverDiscoveryOrder();
 
 private:
     //! Populate \a model with an adapter that has a minimal device schema and


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - New devices now select the Modbus adapter by default when available.
  - Device reconciliation consistently preserves Modbus as the preferred adapter for shared default devices.
  - First-install settings are applied immediately before the quick-start dialog appears.
- **Tests**
  - Added coverage for Modbus adapter selection and device reconciliation in different adapter ordering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->