### PR TITLE
Show invalid device message for unknown device rows

### DIFF
--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -282,6 +282,13 @@ void ExpressionsDialog::startNextDescribe()
     _pDescribeManager = nullptr;
     while (_nextDescribeRow < _pendingDescribeAddresses.size() && _pDescribeManager == nullptr)
     {
+        if (_pSettingsModel != nullptr && !_pSettingsModel->hasDevice(_pendingDescribeDeviceIds[_nextDescribeRow]))
+        {
+            setDescribeRowText(_nextDescribeRow, QStringLiteral("Invalid device"));
+            _nextDescribeRow++;
+            continue;
+        }
+
         AdapterManager* pManager = managerForDescribeRow(_nextDescribeRow);
         if (pManager != nullptr)
         {
@@ -298,6 +305,20 @@ void ExpressionsDialog::startNextDescribe()
     }
 }
 
+/*!
+ * \brief Set the description text of a pending-describe row, if the row still has an item.
+ * \param row  Row index into the describe table.
+ * \param text Text to set; ignored when empty.
+ */
+void ExpressionsDialog::setDescribeRowText(qint32 row, const QString& text)
+{
+    QTableWidgetItem* pItem = _pUi->tblExpressionInput->item(row, 0);
+    if (pItem != nullptr && !text.isEmpty())
+    {
+        pItem->setText(text);
+    }
+}
+
 void ExpressionsDialog::handleDescribeDataPointResult(const QJsonObject& result)
 {
     if (_nextDescribeRow >= _pendingDescribeAddresses.size())
@@ -305,12 +326,7 @@ void ExpressionsDialog::handleDescribeDataPointResult(const QJsonObject& result)
         return;
     }
 
-    QString description = result["description"].toString();
-    QTableWidgetItem* pItem = _pUi->tblExpressionInput->item(_nextDescribeRow, 0);
-    if (pItem != nullptr && !description.isEmpty())
-    {
-        pItem->setText(description);
-    }
+    setDescribeRowText(_nextDescribeRow, result["description"].toString());
 
     _nextDescribeRow++;
     startNextDescribe();

--- a/src/dialogs/expressionsdialog.h
+++ b/src/dialogs/expressionsdialog.h
@@ -45,6 +45,7 @@ private:
     void populateHelpAdapters();
     void requestHelpForAdapter(const QString& adapterId);
     AdapterManager* managerForDescribeRow(qint32 row) const;
+    void setDescribeRowText(qint32 row, const QString& text);
 
     Ui::ExpressionsDialog* _pUi;
 

--- a/tests/dialogs/tst_expressionsdialog.cpp
+++ b/tests/dialogs/tst_expressionsdialog.cpp
@@ -198,6 +198,28 @@ void TestExpressionsDialog::describeSkipsIdleAdapter()
     QCOMPARE(_pMockAdapterManager->describeCalls[0], QStringLiteral("${40002}"));
 }
 
+void TestExpressionsDialog::describeShowsInvalidDeviceMessage()
+{
+    /* Device 99 was never added to the settings model */
+    auto* pEdit = _pDialog->findChild<QPlainTextEdit*>("lineExpression");
+    QVERIFY(pEdit != nullptr);
+
+    pEdit->setPlainText(QStringLiteral("${40001@99} + ${40002}"));
+
+    /* Row 0 is skipped without a describe call; the chain continues with row 1 */
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+    QCOMPARE(_pMockAdapterManager->describeCalls[0], QStringLiteral("${40002}"));
+
+    _pMockAdapterManager->injectDescribeResult(QStringLiteral("Modbus reg"));
+
+    auto* pTable = _pDialog->findChild<QTableWidget*>("tblExpressionInput");
+    QVERIFY(pTable != nullptr);
+    QCOMPARE(pTable->item(0, 0)->text(), QStringLiteral("Invalid device"));
+    QCOMPARE(pTable->item(1, 0)->text(), QStringLiteral("Modbus reg"));
+
+    QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
+}
+
 void TestExpressionsDialog::helpComboHiddenWithSingleAdapter()
 {
     /* Use isHidden(): the surrounding info panel (widgetInfo) starts collapsed,

--- a/tests/dialogs/tst_expressionsdialog.h
+++ b/tests/dialogs/tst_expressionsdialog.h
@@ -77,6 +77,7 @@ private slots:
     void describeRoutedPerDeviceAdapter();
     void describeSkipsUnavailableAdapter();
     void describeSkipsIdleAdapter();
+    void describeShowsInvalidDeviceMessage();
     void helpComboHiddenWithSingleAdapter();
     void helpComboVisibleWithTwoAdapters();
     void helpRoutedToSelectedAdapter();


### PR DESCRIPTION
## Summary

- `ExpressionsDialog::startNextDescribe()` previously resolved a row's owning adapter via `SettingsModel::adapterIdForDevice()`, which silently falls back to the `"modbus"` adapter id for a device id that was never registered (a default-constructed `Device` hardcodes `_adapterId("modbus")`). An expression referencing an unknown device (e.g. `${40001@99}`) would therefore be silently routed to the modbus adapter instead of surfacing any error.
- `startNextDescribe()` now checks `SettingsModel::hasDevice()` first; when the device is unknown, the row's description is set to `"Invalid device"` and the describe chain moves on to the next row, without calling into the adapter at all.
- Extracted the row-text-setting logic (previously inline in `handleDescribeDataPointResult()`) into a small `setDescribeRowText()` helper, reused by both code paths.

## Test plan

- [x] Added `TestExpressionsDialog::describeShowsInvalidDeviceMessage()` covering an expression that references an unregistered device id, verifying no describe call is made for that row and the table shows `"Invalid device"` while the following row (on a known adapter) still resolves normally.
- [ ] CI build/test/quality checks (not runnable in this cloud container — see project `CLAUDE.md`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY7RJBxQXsffqVHBp6h3EJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Expressions referencing unavailable devices are now clearly marked as **“Invalid device”**.
  - Processing continues correctly for other valid expressions instead of stopping unexpectedly.

- **Tests**
  - Added coverage to verify invalid-device messaging, skipped requests, and continued description processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->