### PR TITLE
Auto-log debug output to a temp file when debug logging is enabled

### DIFF
--- a/src/dialogs/diagnosticdialog.cpp
+++ b/src/dialogs/diagnosticdialog.cpp
@@ -4,6 +4,7 @@
 #include "importexport/diagnosticexporter.h"
 #include "models/diagnosticfilter.h"
 #include "models/diagnosticmodel.h"
+#include "util/debuglogfilewriter.h"
 #include "util/fileselectionhelper.h"
 #include "util/scopelogging.h"
 #include "util/util.h"
@@ -165,7 +166,10 @@ void DiagnosticDialog::handleEnableDebugLog(Qt::CheckState state)
     if (state == Qt::Checked)
     {
         _pDiagnosticModel->setMinimumSeverityLevel(Diagnostic::LOG_DEBUG);
-        ScopeLogging::Logger().setDebugFileLoggingEnabled(true);
+        if (!ScopeLogging::Logger().setDebugFileLoggingEnabled(true))
+        {
+            Util::showError(tr("Failed to open debug log file (%1)").arg(DebugLogFileWriter::defaultFilePath()));
+        }
 
         _pUi->checkDebug->setChecked(true);
         _pUi->checkDebug->setEnabled(true);

--- a/src/dialogs/diagnosticdialog.cpp
+++ b/src/dialogs/diagnosticdialog.cpp
@@ -13,6 +13,7 @@
 #include <QFileDialog>
 #include <QModelIndex>
 #include <QScrollBar>
+#include <QSignalBlocker>
 #include <algorithm>
 
 DiagnosticDialog::DiagnosticDialog(DiagnosticModel* pDiagnosticModel, QWidget* parent)
@@ -22,9 +23,9 @@ DiagnosticDialog::DiagnosticDialog(DiagnosticModel* pDiagnosticModel, QWidget* p
     _bAutoScroll = false;
 
     _pUi->label->setText(tr("You should only enable this when you want to debug the connection. When "
-                             "enabled, all data reads are logged. This will increase the log size very "
-                             "much. While enabled, all logs are also automatically appended to %1.")
-                              .arg(DebugLogFileWriter::defaultFilePath()));
+                            "enabled, all data reads are logged. This will increase the log size very "
+                            "much. While enabled, all logs are also automatically appended to %1.")
+                           .arg(DebugLogFileWriter::defaultFilePath()));
 
     _pDiagnosticModel = pDiagnosticModel;
 
@@ -37,7 +38,8 @@ DiagnosticDialog::DiagnosticDialog(DiagnosticModel* pDiagnosticModel, QWidget* p
     _categoryFilterGroup.addButton(_pUi->checkWarning);
     _categoryFilterGroup.addButton(_pUi->checkDebug);
 
-    connect(&_categoryFilterGroup, QOverload<int>::of(&QButtonGroup::idClicked), this, &DiagnosticDialog::handleFilterChange);
+    connect(&_categoryFilterGroup, QOverload<int>::of(&QButtonGroup::idClicked), this,
+            &DiagnosticDialog::handleFilterChange);
 
     this->handleFilterChange(); // Update filter
 
@@ -47,10 +49,12 @@ DiagnosticDialog::DiagnosticDialog(DiagnosticModel* pDiagnosticModel, QWidget* p
 
     connect(_pUi->checkDebugLogs, &QCheckBox::checkStateChanged, this, &DiagnosticDialog::handleEnableDebugLog);
 
-    connect(_pUi->listError->verticalScrollBar(), &QScrollBar::valueChanged, this, &DiagnosticDialog::handleScrollbarChange);
+    connect(_pUi->listError->verticalScrollBar(), &QScrollBar::valueChanged, this,
+            &DiagnosticDialog::handleScrollbarChange);
 
     // Disable auto scroll when selecting an item
-    connect(_pUi->listError->selectionModel(), &QItemSelectionModel::selectionChanged, this, &DiagnosticDialog::handleErrorSelectionChanged);
+    connect(_pUi->listError->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+            &DiagnosticDialog::handleErrorSelectionChanged);
 
     // Handle layout change (filter change, add, clear, ...)
     connect(_pDiagnosticModel, &QAbstractItemModel::rowsInserted, this, &DiagnosticDialog::handleLogsChanged);
@@ -123,12 +127,11 @@ void DiagnosticDialog::handleCheckAutoScrollChanged(Qt::CheckState state)
     {
         setAutoScroll(true);
     }
-
 }
 
 void DiagnosticDialog::handleScrollbarChange()
 {
-    const QScrollBar * pScroll = _pUi->listError->verticalScrollBar();
+    const QScrollBar* pScroll = _pUi->listError->verticalScrollBar();
     if (pScroll->value() == pScroll->maximum())
     {
         setAutoScroll(true);
@@ -173,7 +176,13 @@ void DiagnosticDialog::handleEnableDebugLog(Qt::CheckState state)
         _pDiagnosticModel->setMinimumSeverityLevel(Diagnostic::LOG_DEBUG);
         if (!ScopeLogging::Logger().setDebugFileLoggingEnabled(true))
         {
+            _pDiagnosticModel->setMinimumSeverityLevel(Diagnostic::LOG_INFO);
+
+            const QSignalBlocker blocker(_pUi->checkDebugLogs);
+            _pUi->checkDebugLogs->setChecked(false);
+
             Util::showError(tr("Failed to open debug log file (%1)").arg(DebugLogFileWriter::defaultFilePath()));
+            return;
         }
 
         _pUi->checkDebug->setChecked(true);
@@ -194,8 +203,7 @@ void DiagnosticDialog::handleEnableDebugLog(Qt::CheckState state)
 void DiagnosticDialog::handleExportLog()
 {
     QFileDialog dialog(this);
-    FileSelectionHelper::configureFileDialog(&dialog,
-                                             FileSelectionHelper::DIALOG_TYPE_SAVE,
+    FileSelectionHelper::configureFileDialog(&dialog, FileSelectionHelper::DIALOG_TYPE_SAVE,
                                              FileSelectionHelper::FILE_TYPE_LOG);
 
     QString selectedFile = FileSelectionHelper::showDialog(&dialog);
@@ -224,7 +232,7 @@ void DiagnosticDialog::showContextMenu(const QPoint& pos)
 
 void DiagnosticDialog::handleCopyDiagnostics()
 {
-    QModelIndexList indexlist =_pUi->listError->selectionModel()->selectedRows();
+    QModelIndexList indexlist = _pUi->listError->selectionModel()->selectedRows();
     std::sort(indexlist.begin(), indexlist.end(), std::less<QModelIndex>());
 
     QString clipboardText;
@@ -258,7 +266,7 @@ void DiagnosticDialog::updateScroll()
     }
     else
     {
-       // Don't auto scroll
+        // Don't auto scroll
     }
 }
 
@@ -266,7 +274,8 @@ void DiagnosticDialog::updateLogCount()
 {
     if (_pSeverityProxyFilter->rowCount())
     {
-        _pUi->grpBoxLogs->setTitle(QString("Logs (%1/%2)").arg(_pSeverityProxyFilter->rowCount()).arg(_pDiagnosticModel->size()));
+        _pUi->grpBoxLogs->setTitle(
+          QString("Logs (%1/%2)").arg(_pSeverityProxyFilter->rowCount()).arg(_pDiagnosticModel->size()));
     }
     else
     {

--- a/src/dialogs/diagnosticdialog.cpp
+++ b/src/dialogs/diagnosticdialog.cpp
@@ -21,6 +21,11 @@ DiagnosticDialog::DiagnosticDialog(DiagnosticModel* pDiagnosticModel, QWidget* p
     _pUi->setupUi(this);
     _bAutoScroll = false;
 
+    _pUi->label->setText(tr("You should only enable this when you want to debug the connection. When "
+                             "enabled, all data reads are logged. This will increase the log size very "
+                             "much. While enabled, all logs are also automatically appended to %1.")
+                              .arg(DebugLogFileWriter::defaultFilePath()));
+
     _pDiagnosticModel = pDiagnosticModel;
 
     _pSeverityProxyFilter = new DiagnosticFilter();

--- a/src/dialogs/diagnosticdialog.cpp
+++ b/src/dialogs/diagnosticdialog.cpp
@@ -165,6 +165,7 @@ void DiagnosticDialog::handleEnableDebugLog(Qt::CheckState state)
     if (state == Qt::Checked)
     {
         _pDiagnosticModel->setMinimumSeverityLevel(Diagnostic::LOG_DEBUG);
+        ScopeLogging::Logger().setDebugFileLoggingEnabled(true);
 
         _pUi->checkDebug->setChecked(true);
         _pUi->checkDebug->setEnabled(true);
@@ -177,6 +178,7 @@ void DiagnosticDialog::handleEnableDebugLog(Qt::CheckState state)
         handleFilterChange();
 
         _pDiagnosticModel->setMinimumSeverityLevel(Diagnostic::LOG_INFO);
+        ScopeLogging::Logger().setDebugFileLoggingEnabled(false);
     }
 }
 

--- a/src/dialogs/diagnosticdialog.cpp
+++ b/src/dialogs/diagnosticdialog.cpp
@@ -13,7 +13,6 @@
 #include <QFileDialog>
 #include <QModelIndex>
 #include <QScrollBar>
-#include <QSignalBlocker>
 #include <algorithm>
 
 DiagnosticDialog::DiagnosticDialog(DiagnosticModel* pDiagnosticModel, QWidget* parent)
@@ -176,13 +175,7 @@ void DiagnosticDialog::handleEnableDebugLog(Qt::CheckState state)
         _pDiagnosticModel->setMinimumSeverityLevel(Diagnostic::LOG_DEBUG);
         if (!ScopeLogging::Logger().setDebugFileLoggingEnabled(true))
         {
-            _pDiagnosticModel->setMinimumSeverityLevel(Diagnostic::LOG_INFO);
-
-            const QSignalBlocker blocker(_pUi->checkDebugLogs);
-            _pUi->checkDebugLogs->setChecked(false);
-
             Util::showError(tr("Failed to open debug log file (%1)").arg(DebugLogFileWriter::defaultFilePath()));
-            return;
         }
 
         _pUi->checkDebug->setChecked(true);

--- a/src/util/debuglogfilewriter.cpp
+++ b/src/util/debuglogfilewriter.cpp
@@ -1,12 +1,15 @@
 #include "util/debuglogfilewriter.h"
 
 #include <QDir>
+#include <QMutexLocker>
 
 /*!
  * \brief Constructor for DebugLogFileWriter
  * \param filePath  Path of the file to append log lines to when enabled
  */
-DebugLogFileWriter::DebugLogFileWriter(QString filePath) : _file(filePath) {}
+DebugLogFileWriter::DebugLogFileWriter(QString filePath) : _file(filePath)
+{
+}
 
 /*!
  * \brief Default location of the debug log file: a fixed name in the OS temp folder
@@ -27,7 +30,9 @@ QString DebugLogFileWriter::defaultFilePath()
  */
 bool DebugLogFileWriter::setEnabled(bool bEnabled)
 {
-    if (bEnabled == isEnabled())
+    const QMutexLocker locker(&_mutex);
+
+    if (bEnabled == _file.isOpen())
     {
         return true;
     }
@@ -56,6 +61,8 @@ bool DebugLogFileWriter::setEnabled(bool bEnabled)
  */
 bool DebugLogFileWriter::isEnabled() const
 {
+    const QMutexLocker locker(&_mutex);
+
     return _file.isOpen();
 }
 
@@ -65,7 +72,9 @@ bool DebugLogFileWriter::isEnabled() const
  */
 void DebugLogFileWriter::writeLine(const QString& line)
 {
-    if (!isEnabled())
+    const QMutexLocker locker(&_mutex);
+
+    if (!_file.isOpen())
     {
         return;
     }

--- a/src/util/debuglogfilewriter.cpp
+++ b/src/util/debuglogfilewriter.cpp
@@ -1,0 +1,75 @@
+#include "util/debuglogfilewriter.h"
+
+#include <QDir>
+
+/*!
+ * \brief Constructor for DebugLogFileWriter
+ * \param filePath  Path of the file to append log lines to when enabled
+ */
+DebugLogFileWriter::DebugLogFileWriter(QString filePath) : _filePath(filePath), _file(filePath) {}
+
+/*!
+ * \brief Default location of the debug log file: a fixed name in the OS temp folder
+ * \return Default debug log file path
+ */
+QString DebugLogFileWriter::defaultFilePath()
+{
+    const QString cDefaultLogFileName = "ModbusScope-debuglog.txt";
+    QString tempDir = QDir::toNativeSeparators(QDir::tempPath());
+
+    if (tempDir.right(1) != QDir::separator())
+    {
+        tempDir.append(QDir::separator());
+    }
+
+    return tempDir.append(cDefaultLogFileName);
+}
+
+/*!
+ * \brief Enable or disable writing to the debug log file
+ * \param bEnabled  When true, opens the file in append mode (never truncates existing content);
+ *                  when false, closes the file
+ */
+void DebugLogFileWriter::setEnabled(bool bEnabled)
+{
+    if (bEnabled == isEnabled())
+    {
+        return;
+    }
+
+    if (bEnabled)
+    {
+        _file.setFileName(_filePath);
+        _file.open(QIODevice::Append | QIODevice::Text);
+        _stream.setDevice(&_file);
+    }
+    else
+    {
+        _stream.setDevice(nullptr);
+        _file.close();
+    }
+}
+
+/*!
+ * \brief Check whether the debug log file is currently open for writing
+ * \return True when enabled
+ */
+bool DebugLogFileWriter::isEnabled() const
+{
+    return _file.isOpen();
+}
+
+/*!
+ * \brief Append a line to the debug log file
+ * \param line  Line to write (a newline is appended automatically); no-op when not enabled
+ */
+void DebugLogFileWriter::writeLine(const QString& line)
+{
+    if (!isEnabled())
+    {
+        return;
+    }
+
+    _stream << line << "\n";
+    _stream.flush();
+}

--- a/src/util/debuglogfilewriter.cpp
+++ b/src/util/debuglogfilewriter.cpp
@@ -6,7 +6,7 @@
  * \brief Constructor for DebugLogFileWriter
  * \param filePath  Path of the file to append log lines to when enabled
  */
-DebugLogFileWriter::DebugLogFileWriter(QString filePath) : _filePath(filePath), _file(filePath) {}
+DebugLogFileWriter::DebugLogFileWriter(QString filePath) : _file(filePath) {}
 
 /*!
  * \brief Default location of the debug log file: a fixed name in the OS temp folder
@@ -15,32 +15,30 @@ DebugLogFileWriter::DebugLogFileWriter(QString filePath) : _filePath(filePath), 
 QString DebugLogFileWriter::defaultFilePath()
 {
     const QString cDefaultLogFileName = "ModbusScope-debuglog.txt";
-    QString tempDir = QDir::toNativeSeparators(QDir::tempPath());
 
-    if (tempDir.right(1) != QDir::separator())
-    {
-        tempDir.append(QDir::separator());
-    }
-
-    return tempDir.append(cDefaultLogFileName);
+    return QDir::toNativeSeparators(QDir(QDir::tempPath()).filePath(cDefaultLogFileName));
 }
 
 /*!
  * \brief Enable or disable writing to the debug log file
  * \param bEnabled  When true, opens the file in append mode (never truncates existing content);
  *                  when false, closes the file
+ * \return True when the requested state was reached (false when opening the file failed)
  */
-void DebugLogFileWriter::setEnabled(bool bEnabled)
+bool DebugLogFileWriter::setEnabled(bool bEnabled)
 {
     if (bEnabled == isEnabled())
     {
-        return;
+        return true;
     }
 
     if (bEnabled)
     {
-        _file.setFileName(_filePath);
-        _file.open(QIODevice::Append | QIODevice::Text);
+        if (!_file.open(QIODevice::Append | QIODevice::Text))
+        {
+            return false;
+        }
+
         _stream.setDevice(&_file);
     }
     else
@@ -48,6 +46,8 @@ void DebugLogFileWriter::setEnabled(bool bEnabled)
         _stream.setDevice(nullptr);
         _file.close();
     }
+
+    return true;
 }
 
 /*!

--- a/src/util/debuglogfilewriter.h
+++ b/src/util/debuglogfilewriter.h
@@ -1,0 +1,26 @@
+#ifndef DEBUGLOGFILEWRITER_H
+#define DEBUGLOGFILEWRITER_H
+
+#include <QFile>
+#include <QString>
+#include <QTextStream>
+
+class DebugLogFileWriter
+{
+public:
+    explicit DebugLogFileWriter(QString filePath = defaultFilePath());
+
+    static QString defaultFilePath();
+
+    void setEnabled(bool bEnabled);
+    bool isEnabled() const;
+
+    void writeLine(const QString& line);
+
+private:
+    QString _filePath;
+    QFile _file;
+    QTextStream _stream;
+};
+
+#endif // DEBUGLOGFILEWRITER_H

--- a/src/util/debuglogfilewriter.h
+++ b/src/util/debuglogfilewriter.h
@@ -2,6 +2,7 @@
 #define DEBUGLOGFILEWRITER_H
 
 #include <QFile>
+#include <QMutex>
 #include <QString>
 #include <QTextStream>
 
@@ -18,6 +19,7 @@ public:
     void writeLine(const QString& line);
 
 private:
+    mutable QMutex _mutex;
     QFile _file;
     QTextStream _stream;
 };

--- a/src/util/debuglogfilewriter.h
+++ b/src/util/debuglogfilewriter.h
@@ -12,13 +12,12 @@ public:
 
     static QString defaultFilePath();
 
-    void setEnabled(bool bEnabled);
+    bool setEnabled(bool bEnabled);
     bool isEnabled() const;
 
     void writeLine(const QString& line);
 
 private:
-    QString _filePath;
     QFile _file;
     QTextStream _stream;
 };

--- a/src/util/scopelogging.cpp
+++ b/src/util/scopelogging.cpp
@@ -35,6 +35,14 @@ void ScopeLogging::initLogging(DiagnosticModel* pDiagnosticModel)
 #endif
 }
 
+/*!
+ * \brief Route a Qt log message to the diagnostic model and, when enabled, the debug log file
+ *
+ * Installed via qInstallMessageHandler(), which Qt may invoke from any thread that logs a
+ * message. This codebase does not use worker threads today, so all calls happen to originate
+ * from the main thread; a future change that logs from a background thread would need to
+ * synchronize access to _pDiagnosticModel and _debugLogFileWriter here.
+ */
 void ScopeLogging::handleLog(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
     Diagnostic::LogSeverity logSeverity;
@@ -77,10 +85,11 @@ void ScopeLogging::handleLog(QtMsgType type, const QMessageLogContext& context, 
 /*!
  * \brief Enable or disable automatically appending all log messages to a file in the temp folder
  * \param bEnabled  When true, log messages are appended (never truncating existing content)
+ * \return True on success, false when enabling failed (e.g. the temp folder is not writable)
  */
-void ScopeLogging::setDebugFileLoggingEnabled(bool bEnabled)
+bool ScopeLogging::setDebugFileLoggingEnabled(bool bEnabled)
 {
-    _debugLogFileWriter.setEnabled(bEnabled);
+    return _debugLogFileWriter.setEnabled(bEnabled);
 }
 
 namespace ModbusScopeLog {

--- a/src/util/scopelogging.cpp
+++ b/src/util/scopelogging.cpp
@@ -61,11 +61,26 @@ void ScopeLogging::handleLog(QtMsgType type, const QMessageLogContext& context, 
         _pDiagnosticModel->addLog(context.category, logSeverity, offset, msg);
     }
 
+    if (_debugLogFileWriter.isEnabled())
+    {
+        Diagnostic log(context.category, logSeverity, offset, msg);
+        _debugLogFileWriter.writeLine(log.toExportString());
+    }
+
 #if 0
     QByteArray localMsg = msg.toLocal8Bit();
 
     fprintf(stderr, "%08d - %s\n", offset, localMsg.constData());
 #endif
+}
+
+/*!
+ * \brief Enable or disable automatically appending all log messages to a file in the temp folder
+ * \param bEnabled  When true, log messages are appended (never truncating existing content)
+ */
+void ScopeLogging::setDebugFileLoggingEnabled(bool bEnabled)
+{
+    _debugLogFileWriter.setEnabled(bEnabled);
 }
 
 namespace ModbusScopeLog {

--- a/src/util/scopelogging.cpp
+++ b/src/util/scopelogging.cpp
@@ -3,12 +3,37 @@
 #include "models/diagnosticmodel.h"
 
 #include <QDateTime>
+#include <QMetaObject>
 
 Q_LOGGING_CATEGORY(scopeComm, "scope.comm")
 Q_LOGGING_CATEGORY(scopeAdapter, "scope.comm.adapter")
 Q_LOGGING_CATEGORY(scopeGeneralInfo, "scope.general.info")
 Q_LOGGING_CATEGORY(scopePreset, "scope.preset")
 Q_LOGGING_CATEGORY(scopeUi, "scope.ui")
+
+namespace {
+
+/*!
+ * \brief Functor that delivers a single log entry to a DiagnosticModel
+ *
+ * Used with QMetaObject::invokeMethod() to move the addLog() call onto the model's own
+ * thread, since ScopeLogging::handleLog() may be invoked by Qt from any thread.
+ */
+struct LogDispatcher
+{
+    DiagnosticModel* pModel;
+    QString category;
+    Diagnostic::LogSeverity severity;
+    qint32 offset;
+    QString message;
+
+    void operator()() const
+    {
+        pModel->addLog(category, severity, offset, message);
+    }
+};
+
+} // namespace
 
 ScopeLogging::ScopeLogging()
 {
@@ -39,9 +64,9 @@ void ScopeLogging::initLogging(DiagnosticModel* pDiagnosticModel)
  * \brief Route a Qt log message to the diagnostic model and, when enabled, the debug log file
  *
  * Installed via qInstallMessageHandler(), which Qt may invoke from any thread that logs a
- * message. This codebase does not use worker threads today, so all calls happen to originate
- * from the main thread; a future change that logs from a background thread would need to
- * synchronize access to _pDiagnosticModel and _debugLogFileWriter here.
+ * message. DiagnosticModel is not thread-safe, so DiagnosticModel::addLog() is dispatched onto
+ * the model's own (GUI) thread instead of being called directly. DebugLogFileWriter guards its
+ * own state internally, so it can be accessed directly from whichever thread is logging.
  */
 void ScopeLogging::handleLog(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
@@ -66,7 +91,10 @@ void ScopeLogging::handleLog(QtMsgType type, const QMessageLogContext& context, 
 
     if (_pDiagnosticModel != nullptr)
     {
-        _pDiagnosticModel->addLog(context.category, logSeverity, offset, msg);
+        const QString category = QString::fromUtf8(context.category);
+
+        QMetaObject::invokeMethod(_pDiagnosticModel,
+                                  LogDispatcher{ _pDiagnosticModel, category, logSeverity, offset, msg });
     }
 
     if (_debugLogFileWriter.isEnabled())

--- a/src/util/scopelogging.h
+++ b/src/util/scopelogging.h
@@ -25,7 +25,7 @@ public:
 
     void handleLog(QtMsgType type, const QMessageLogContext& context, const QString& msg);
 
-    void setDebugFileLoggingEnabled(bool bEnabled);
+    bool setDebugFileLoggingEnabled(bool bEnabled);
 
 private:
     qint64 _logStartTime;

--- a/src/util/scopelogging.h
+++ b/src/util/scopelogging.h
@@ -3,6 +3,8 @@
 
 #include <QLoggingCategory>
 
+#include "util/debuglogfilewriter.h"
+
 Q_DECLARE_LOGGING_CATEGORY(scopeAdapter)
 Q_DECLARE_LOGGING_CATEGORY(scopeComm)
 Q_DECLARE_LOGGING_CATEGORY(scopeGeneralInfo)
@@ -23,10 +25,13 @@ public:
 
     void handleLog(QtMsgType type, const QMessageLogContext& context, const QString& msg);
 
+    void setDebugFileLoggingEnabled(bool bEnabled);
+
 private:
     qint64 _logStartTime;
 
     DiagnosticModel* _pDiagnosticModel;
+    DebugLogFileWriter _debugLogFileWriter;
 };
 
 inline ScopeLogging& ScopeLogging::Logger()

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_xtest(tst_debuglogfilewriter)
 add_xtest(tst_expressionchecker)
 add_xtest(tst_expressionstatus)
 add_xtest(tst_formatdatetime)

--- a/tests/util/tst_debuglogfilewriter.cpp
+++ b/tests/util/tst_debuglogfilewriter.cpp
@@ -5,22 +5,15 @@
 
 #include <QDir>
 #include <QFile>
+#include <QTemporaryDir>
 #include <QTest>
-
-void TestDebugLogFileWriter::init()
-{
-    _pTempDir = new QTemporaryDir();
-    QVERIFY(_pTempDir->isValid());
-}
-
-void TestDebugLogFileWriter::cleanup()
-{
-    delete _pTempDir;
-}
 
 void TestDebugLogFileWriter::writeLineWhileDisabledDoesNothing()
 {
-    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString filePath = QDir(tmpDir.path()).filePath("debug.log");
     DebugLogFileWriter writer(filePath);
 
     writer.writeLine("should not be written");
@@ -30,13 +23,16 @@ void TestDebugLogFileWriter::writeLineWhileDisabledDoesNothing()
 
 void TestDebugLogFileWriter::writeLineWhileEnabledAppendsLines()
 {
-    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString filePath = QDir(tmpDir.path()).filePath("debug.log");
     DebugLogFileWriter writer(filePath);
 
-    writer.setEnabled(true);
+    QVERIFY(writer.setEnabled(true));
     writer.writeLine("foo");
     writer.writeLine("bar");
-    writer.setEnabled(false);
+    QVERIFY(writer.setEnabled(false));
 
     QFile file(filePath);
     QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
@@ -45,10 +41,13 @@ void TestDebugLogFileWriter::writeLineWhileEnabledAppendsLines()
 
 void TestDebugLogFileWriter::writtenLinesAreFlushedImmediately()
 {
-    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString filePath = QDir(tmpDir.path()).filePath("debug.log");
     DebugLogFileWriter writer(filePath);
 
-    writer.setEnabled(true);
+    QVERIFY(writer.setEnabled(true));
     writer.writeLine("flushed");
 
     QFile file(filePath);
@@ -58,21 +57,40 @@ void TestDebugLogFileWriter::writtenLinesAreFlushedImmediately()
 
 void TestDebugLogFileWriter::reenablingAppendsRatherThanTruncates()
 {
-    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString filePath = QDir(tmpDir.path()).filePath("debug.log");
 
     DebugLogFileWriter firstWriter(filePath);
-    firstWriter.setEnabled(true);
+    QVERIFY(firstWriter.setEnabled(true));
     firstWriter.writeLine("first session");
-    firstWriter.setEnabled(false);
+    QVERIFY(firstWriter.setEnabled(false));
 
     DebugLogFileWriter secondWriter(filePath);
-    secondWriter.setEnabled(true);
+    QVERIFY(secondWriter.setEnabled(true));
     secondWriter.writeLine("second session");
-    secondWriter.setEnabled(false);
+    QVERIFY(secondWriter.setEnabled(false));
 
     QFile file(filePath);
     QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
     QCOMPARE(QString(file.readAll()), QStringLiteral("first session\nsecond session\n"));
+}
+
+void TestDebugLogFileWriter::setEnabledFailsForUnwritablePath()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    // Parent directory does not exist, so QFile::open() must fail
+    const QString filePath = QDir(tmpDir.path()).filePath("missing-subdir/debug.log");
+    DebugLogFileWriter writer(filePath);
+
+    QVERIFY(!writer.setEnabled(true));
+    QVERIFY(!writer.isEnabled());
+
+    writer.writeLine("should not be written");
+    QVERIFY(!QFile::exists(filePath));
 }
 
 QTEST_GUILESS_MAIN(TestDebugLogFileWriter)

--- a/tests/util/tst_debuglogfilewriter.cpp
+++ b/tests/util/tst_debuglogfilewriter.cpp
@@ -1,0 +1,78 @@
+
+#include "tst_debuglogfilewriter.h"
+
+#include "util/debuglogfilewriter.h"
+
+#include <QDir>
+#include <QFile>
+#include <QTest>
+
+void TestDebugLogFileWriter::init()
+{
+    _pTempDir = new QTemporaryDir();
+    QVERIFY(_pTempDir->isValid());
+}
+
+void TestDebugLogFileWriter::cleanup()
+{
+    delete _pTempDir;
+}
+
+void TestDebugLogFileWriter::writeLineWhileDisabledDoesNothing()
+{
+    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+    DebugLogFileWriter writer(filePath);
+
+    writer.writeLine("should not be written");
+
+    QVERIFY(!QFile::exists(filePath));
+}
+
+void TestDebugLogFileWriter::writeLineWhileEnabledAppendsLines()
+{
+    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+    DebugLogFileWriter writer(filePath);
+
+    writer.setEnabled(true);
+    writer.writeLine("foo");
+    writer.writeLine("bar");
+    writer.setEnabled(false);
+
+    QFile file(filePath);
+    QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
+    QCOMPARE(QString(file.readAll()), QStringLiteral("foo\nbar\n"));
+}
+
+void TestDebugLogFileWriter::writtenLinesAreFlushedImmediately()
+{
+    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+    DebugLogFileWriter writer(filePath);
+
+    writer.setEnabled(true);
+    writer.writeLine("flushed");
+
+    QFile file(filePath);
+    QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
+    QCOMPARE(QString(file.readAll()), QStringLiteral("flushed\n"));
+}
+
+void TestDebugLogFileWriter::reenablingAppendsRatherThanTruncates()
+{
+    const QString filePath = QDir(_pTempDir->path()).filePath("debug.log");
+
+    DebugLogFileWriter firstWriter(filePath);
+    firstWriter.setEnabled(true);
+    firstWriter.writeLine("first session");
+    firstWriter.setEnabled(false);
+
+    DebugLogFileWriter secondWriter(filePath);
+    secondWriter.setEnabled(true);
+    secondWriter.writeLine("second session");
+    secondWriter.setEnabled(false);
+
+    QFile file(filePath);
+    QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
+    QCOMPARE(QString(file.readAll()), QStringLiteral("first session\nsecond session\n"));
+}
+
+QTEST_GUILESS_MAIN(TestDebugLogFileWriter)

--- a/tests/util/tst_debuglogfilewriter.h
+++ b/tests/util/tst_debuglogfilewriter.h
@@ -3,7 +3,6 @@
 #define TST_DEBUGLOGFILEWRITER_H
 
 #include <QObject>
-#include <QTemporaryDir>
 
 class TestDebugLogFileWriter : public QObject
 {
@@ -11,16 +10,13 @@ class TestDebugLogFileWriter : public QObject
 
 private slots:
 
-    void init();
-    void cleanup();
-
     void writeLineWhileDisabledDoesNothing();
     void writeLineWhileEnabledAppendsLines();
     void writtenLinesAreFlushedImmediately();
     void reenablingAppendsRatherThanTruncates();
+    void setEnabledFailsForUnwritablePath();
 
 private:
-    QTemporaryDir* _pTempDir;
 };
 
 #endif /* TST_DEBUGLOGFILEWRITER_H */

--- a/tests/util/tst_debuglogfilewriter.h
+++ b/tests/util/tst_debuglogfilewriter.h
@@ -1,0 +1,26 @@
+
+#ifndef TST_DEBUGLOGFILEWRITER_H
+#define TST_DEBUGLOGFILEWRITER_H
+
+#include <QObject>
+#include <QTemporaryDir>
+
+class TestDebugLogFileWriter : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    void init();
+    void cleanup();
+
+    void writeLineWhileDisabledDoesNothing();
+    void writeLineWhileEnabledAppendsLines();
+    void writtenLinesAreFlushedImmediately();
+    void reenablingAppendsRatherThanTruncates();
+
+private:
+    QTemporaryDir* _pTempDir;
+};
+
+#endif /* TST_DEBUGLOGFILEWRITER_H */


### PR DESCRIPTION
Add DebugLogFileWriter, which appends log lines to a fixed file in the
OS temp folder (ModbusScope-debuglog.txt), never truncating existing
content. ScopeLogging now writes every log message through it while
enabled, and the Diagnostic dialog's "Enable extensive debug logging"
checkbox toggles it alongside the existing severity threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional debug log file output.
  * Diagnostics guidance now shows the default debug log path.
  * Debug logging can be enabled or disabled from the diagnostics dialog.
  * Log messages are appended and flushed immediately for easier troubleshooting.
* **Bug Fixes**
  * Displays an error when the log file cannot be opened.
  * Disabling debug logs also stops file logging.
* **Tests**
  * Added coverage for writing, appending, re-enabling, disabled logging and unwritable files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->