### PR TITLE
Improve adapter lifecycle

### DIFF
--- a/Plan/multi-device-coherence-audit.md
+++ b/Plan/multi-device-coherence-audit.md
@@ -154,7 +154,7 @@ Where: `src/dialogs/adaptersettings.cpp:158` · `src/customwidgets/deviceconfigt
 
 ## 5. Runtime behaviour with more than one adapter
 
-### F13 — A mixed idle/ready fleet deadlocks the start path [High]
+### F13 — A mixed idle/ready fleet deadlocks the start path [High] — Fixed
 
 `AdapterHub::isAdapterReady()` requires *all* managers ready; `isAdapterIdle()` requires *all* idle. `startCommunication()` handles exactly those two cases:
 
@@ -165,6 +165,8 @@ else { wait; if (isAdapterIdle()) initAdapter(); }
 ```
 
 When one adapter has crashed to `IDLE` and another is still `AWAITING_CONFIG`, neither predicate holds. The poll enters `WaitingForAdapter`, arms a single-shot connection to `adapterReady`, and calls nothing — and `adapterReady` only fires when `_pendingReadyAdapters` drains, which requires an `initAdapter()` or `stopSession()` that never comes. The state is reachable: any adapter process dying mid-session produces it, and `stopSession()` skips both idle and ready managers, so it persists across a stop/start.
+
+**Fixed:** `AdapterHub::initAdapter()` is now idempotent and per-manager — it (re)starts only the managers currently `IDLE`, leaving ready/mid-handshake/active managers untouched. `AdapterPoll` no longer reasons about a fleet-wide idle predicate at all; the aggregate `isAdapterIdle()` was removed. Regression test: `tst_adapterhub.cpp::initAdapterReinitializesOnlyIdleManagers`.
 
 Where: `src/communication/adapterpoll.cpp:62` · `src/ProtocolAdapter/adapterhub.cpp:102` · `:160` · `:177`
 

--- a/src/ProtocolAdapter/adapterhub.cpp
+++ b/src/ProtocolAdapter/adapterhub.cpp
@@ -24,45 +24,60 @@ AdapterHub::AdapterHub(QObject* parent) : QObject(parent), _pSettingsModel(nullp
 {
 }
 
-/*! \brief Discover adapter binaries and start the initialization handshake for each.
+/*! \brief Ensure every discovered adapter has an initialization handshake in flight or complete.
  *
- * Uses AdapterDiscovery to locate binaries in the application directory, creates one
- * AdapterManager per binary, and calls initAdapter() on each. The hub's adapterReady()
- * signal is emitted only after all managers have reached AWAITING_CONFIG state.
+ * On the first call, uses AdapterDiscovery to locate adapter binaries in the application
+ * directory and creates one AdapterManager per binary. On every call, including the first,
+ * (re)starts the handshake only for managers currently in IDLE state; a manager that is already
+ * ready, mid-handshake, active, or degraded is left untouched.
+ *
+ * This makes the call idempotent and safe to repeat at any time - in particular, when one
+ * adapter has crashed back to IDLE while its siblings are unaffected, only the crashed one is
+ * restarted. The hub's adapterReady() signal still fires once every manager - old and newly
+ * restarted alike - is back in AWAITING_CONFIG.
  */
 void AdapterHub::initAdapter()
 {
-    qDeleteAll(_adapterManagers);
-    _adapterManagers.clear();
-    _pendingReadyAdapters.clear();
-    _pendingStartAdapters.clear();
-
-    const QList<AdapterInfo> discovered = AdapterDiscovery::discover(QCoreApplication::applicationDirPath());
-
-    if (discovered.isEmpty())
+    if (_adapterManagers.isEmpty())
     {
-        qCWarning(scopeComm) << "AdapterHub: no adapter binaries found in" << QCoreApplication::applicationDirPath();
-        emit sessionError(QStringLiteral("No adapter binaries found"));
-        return;
-    }
+        _pendingReadyAdapters.clear();
+        _pendingStartAdapters.clear();
 
-    for (const AdapterInfo& info : discovered)
-    {
-        if (_adapterManagers.contains(info.id))
+        const QList<AdapterInfo> discovered = AdapterDiscovery::discover(QCoreApplication::applicationDirPath());
+
+        if (discovered.isEmpty())
         {
-            qCWarning(scopeComm) << "AdapterHub: duplicate adapter id" << info.id << "for" << info.binaryPath
-                                 << "- skipping";
-            continue;
+            qCWarning(scopeComm) << "AdapterHub: no adapter binaries found in"
+                                 << QCoreApplication::applicationDirPath();
+            emit sessionError(QStringLiteral("No adapter binaries found"));
+            return;
         }
-        auto* mgr = new AdapterManager(info.id, info.binaryPath, _pSettingsModel, this);
-        _adapterManagers.insert(info.id, mgr);
-        connectManager(mgr, info.id);
+
+        for (const AdapterInfo& info : discovered)
+        {
+            if (_adapterManagers.contains(info.id))
+            {
+                qCWarning(scopeComm) << "AdapterHub: duplicate adapter id" << info.id << "for" << info.binaryPath
+                                     << "- skipping";
+                continue;
+            }
+            auto* mgr = new AdapterManager(info.id, info.binaryPath, _pSettingsModel, this);
+            _adapterManagers.insert(info.id, mgr);
+            connectManager(mgr, info.id);
+        }
     }
 
+    /* Single-pass loop is safe only because AdapterManager::initAdapter() is fully asynchronous
+       (it spawns a subprocess) and can never re-enter onManagerAdapterReady() synchronously from
+       within this loop, unlike stopSession()'s two-pass pattern below, which guards against a
+       degraded manager's synchronous adapterReady(). */
     for (auto it = _adapterManagers.constBegin(); it != _adapterManagers.constEnd(); ++it)
     {
-        _pendingReadyAdapters.insert(it.key());
-        it.value()->initAdapter();
+        if (it.value()->isAdapterIdle())
+        {
+            _pendingReadyAdapters.insert(it.key());
+            it.value()->initAdapter();
+        }
     }
 }
 
@@ -166,23 +181,6 @@ bool AdapterHub::isAdapterReady() const
     for (const AdapterManager* mgr : _adapterManagers)
     {
         if (!mgr->isAdapterReady())
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-/*! \brief Returns true when all adapter managers are in IDLE state (no subprocess running). */
-bool AdapterHub::isAdapterIdle() const
-{
-    if (_adapterManagers.isEmpty())
-    {
-        return true;
-    }
-    for (const AdapterManager* mgr : _adapterManagers)
-    {
-        if (!mgr->isAdapterIdle())
         {
             return false;
         }

--- a/src/ProtocolAdapter/adapterhub.h
+++ b/src/ProtocolAdapter/adapterhub.h
@@ -18,9 +18,11 @@ class SettingsModel;
 /*!
  * \brief Owns and coordinates all discovered adapter managers.
  *
- * On initAdapter(), AdapterHub uses AdapterDiscovery to locate adapter binaries,
- * creates one AdapterManager per binary, and gates the adapterReady() and
- * sessionStarted() signals until all managers have reached the required state.
+ * On the first initAdapter() call, AdapterHub uses AdapterDiscovery to locate adapter
+ * binaries and creates one AdapterManager per binary. Every call, including the first,
+ * (re)starts only the managers currently idle - e.g. after one has crashed - and gates the
+ * adapterReady() and sessionStarted() signals until all managers have reached the required
+ * state.
  *
  * Virtual methods allow a mock subclass to be injected in unit tests via the
  * protected constructor.
@@ -42,7 +44,6 @@ public:
     virtual AdapterManager* adapterManager(const QString& id) const;
     virtual QStringList adapterIds() const;
     virtual bool isAdapterReady() const;
-    virtual bool isAdapterIdle() const;
 
 signals:
     void sessionStarted();

--- a/src/communication/adapterpoll.cpp
+++ b/src/communication/adapterpoll.cpp
@@ -72,11 +72,7 @@ void AdapterPoll::startCommunication(QList<DataPoint>& registerList)
             _adapterReadyConnection = connect(_pAdapterHub, &AdapterHub::adapterReady, this,
                                               &AdapterPoll::onAdapterReady, Qt::SingleShotConnection);
         }
-        if (_pAdapterHub->isAdapterIdle())
-        {
-            _pAdapterHub->initAdapter();
-        }
-        /* else: adapter is already initializing; onAdapterReady fires when it reaches AWAITING_CONFIG */
+        _pAdapterHub->initAdapter();
     }
 }
 

--- a/src/dialogs/adapterdevicesettings.cpp
+++ b/src/dialogs/adapterdevicesettings.cpp
@@ -160,9 +160,9 @@ void AdapterDeviceSettings::sortPagesByDeviceId(QList<QWidget*>& pages, QStringL
 
 /*! \brief Add a new device tab with a unique, auto-incremented device ID.
  *
- * Creates a SettingsModel device via addNewDevice() to obtain a unique ID,
- * sets its adapter, then opens a new DeviceConfigTab pre-populated with
- * the adapter's default values and the assigned ID.
+ * Creates a SettingsModel device with its adapter already assigned, then opens
+ * a new DeviceConfigTab pre-populated with the adapter's default values and the
+ * assigned ID.
  */
 void AdapterDeviceSettings::handleAddTab()
 {
@@ -201,8 +201,7 @@ void AdapterDeviceSettings::handleAddTab()
         }
     }
     const deviceId_t newId = (maxId > 0) ? maxId + 1 : Device::cFirstDeviceId;
-    _pSettingsModel->addDevice(newId);
-    _pSettingsModel->deviceSettings(newId)->setAdapterId(defaultAdapterId);
+    _pSettingsModel->addDevice(newId, defaultAdapterId);
     defaultValues["id"] = static_cast<int>(newId);
 
     auto* tab = new DeviceConfigTab(_pSettingsModel, defaultAdapterId, defaultValues, _pDeviceTabs);

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -12,6 +12,7 @@
 #include <QJsonArray>
 #include <QMenu>
 #include <QResizeEvent>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 
 /*!
@@ -46,6 +47,7 @@ AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel, AdapterHub* 
 
     /* Connect after populating to avoid spurious slot calls during addItem */
     connect(_pUi->cmbDevice, &QComboBox::currentIndexChanged, this, &AddRegisterWidget::onDeviceSelectionChanged);
+    connect(_pSettingsModel, &SettingsModel::deviceListChanged, this, &AddRegisterWidget::refreshDeviceCombo);
 
     connect(_pUi->btnAdd, &QPushButton::clicked, this, &AddRegisterWidget::handleResultAccept);
 
@@ -58,15 +60,39 @@ AddRegisterWidget::AddRegisterWidget(SettingsModel* pSettingsModel, AdapterHub* 
 }
 
 /*!
- * \brief Fills the device combo box with all configured devices.
+ * \brief Clears and refills the device combo box with all configured devices.
  */
 void AddRegisterWidget::populateDeviceCombo()
 {
+    _pUi->cmbDevice->clear();
+
     const QList<deviceId_t> deviceIds = _pSettingsModel->deviceList();
     for (deviceId_t devId : deviceIds)
     {
         _pUi->cmbDevice->addItem(_pSettingsModel->deviceSettings(devId)->name(), QVariant(devId));
     }
+}
+
+/*!
+ * \brief Repopulates the device combo box, preserving the current selection where possible.
+ *
+ * Signals are blocked while the combo box is cleared and rebuilt so the transient,
+ * possibly-empty intermediate states it passes through don't reach applyDevice();
+ * the device is applied exactly once, for the final selection.
+ */
+void AddRegisterWidget::refreshDeviceCombo()
+{
+    const deviceId_t previousSelection = selectedDeviceId();
+
+    {
+        const QSignalBlocker blocker(_pUi->cmbDevice);
+        populateDeviceCombo();
+
+        const int idx = _pUi->cmbDevice->findData(QVariant(previousSelection));
+        _pUi->cmbDevice->setCurrentIndex(idx >= 0 ? idx : 0);
+    }
+
+    applyDevice(selectedDeviceId());
 }
 
 AddRegisterWidget::~AddRegisterWidget()

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -35,6 +35,7 @@ private slots:
     void handleResultAccept();
     void onBuildExpressionResult(const QString& expression);
     void onDeviceSelectionChanged(int index);
+    void refreshDeviceCombo();
 
 private:
     void resetFields();

--- a/src/importexport/projectfilehandler.cpp
+++ b/src/importexport/projectfilehandler.cpp
@@ -303,12 +303,14 @@ void ProjectFileHandler::applyDeviceSettings(const QList<ProjectFileData::Device
 
         const QString adapterId = devSettings.adapterType.isEmpty() ? QString("modbus") : devSettings.adapterType;
 
-        _pSettingsModel->addDevice(devSettings.deviceId);
+        _pSettingsModel->addDevice(devSettings.deviceId, adapterId);
         Device* pDev = _pSettingsModel->deviceSettings(devSettings.deviceId);
         if (devSettings.bName)
         {
             pDev->setName(devSettings.name);
         }
+        /* addDevice() already assigned the adapter for a new device; repeat it so a project
+           file listing the same device id twice keeps its last entry's adapter, as before. */
         pDev->setAdapterId(adapterId);
     }
 }

--- a/src/importexport/projectfilehandler.cpp
+++ b/src/importexport/projectfilehandler.cpp
@@ -302,15 +302,17 @@ void ProjectFileHandler::applyDeviceSettings(const QList<ProjectFileData::Device
         }
 
         const QString adapterId = devSettings.adapterType.isEmpty() ? QString("modbus") : devSettings.adapterType;
+        const QString deviceName = devSettings.bName ? devSettings.name : QString();
 
-        _pSettingsModel->addDevice(devSettings.deviceId, adapterId);
+        _pSettingsModel->addDevice(devSettings.deviceId, adapterId, deviceName);
+
+        /* addDevice() applied both to a new device already; repeat them so a project file
+           listing the same device id twice keeps its last entry's settings, as before. */
         Device* pDev = _pSettingsModel->deviceSettings(devSettings.deviceId);
         if (devSettings.bName)
         {
             pDev->setName(devSettings.name);
         }
-        /* addDevice() already assigned the adapter for a new device; repeat it so a project
-           file listing the same device id twice keeps its last entry's adapter, as before. */
         pDev->setAdapterId(adapterId);
     }
 }

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -100,13 +100,14 @@ deviceId_t SettingsModel::addNewDevice()
 
 /*! \brief Add a device to the model, unless it already exists.
  *
- * The adapter is assigned before deviceListChanged() is emitted, so observers that
- * inspect the new device's owner from that signal (AddRegisterWidget rebuilds its
- * address form there) never see the default adapter of a not-yet-configured device.
+ * The device is fully configured before deviceListChanged() is emitted, so observers
+ * reading it from that signal (AddRegisterWidget rebuilds its address form there and
+ * labels its combo box entries) never see a half-configured device.
  * \param devId      Identifier of the device to add.
  * \param adapterId  Adapter owning the device; empty keeps Device's default adapter.
+ * \param name       Display name of the device; empty keeps Device's default name.
  */
-void SettingsModel::addDevice(deviceId_t devId, const QString& adapterId)
+void SettingsModel::addDevice(deviceId_t devId, const QString& adapterId, const QString& name)
 {
     if (!_devices.contains(devId))
     {
@@ -114,6 +115,10 @@ void SettingsModel::addDevice(deviceId_t devId, const QString& adapterId)
         if (!adapterId.isEmpty())
         {
             _devices[devId].setAdapterId(adapterId);
+        }
+        if (!name.isEmpty())
+        {
+            _devices[devId].setName(name);
         }
         emit deviceListChanged();
     }

--- a/src/models/settingsmodel.cpp
+++ b/src/models/settingsmodel.cpp
@@ -98,11 +98,23 @@ deviceId_t SettingsModel::addNewDevice()
     return newId;
 }
 
-void SettingsModel::addDevice(deviceId_t devId)
+/*! \brief Add a device to the model, unless it already exists.
+ *
+ * The adapter is assigned before deviceListChanged() is emitted, so observers that
+ * inspect the new device's owner from that signal (AddRegisterWidget rebuilds its
+ * address form there) never see the default adapter of a not-yet-configured device.
+ * \param devId      Identifier of the device to add.
+ * \param adapterId  Adapter owning the device; empty keeps Device's default adapter.
+ */
+void SettingsModel::addDevice(deviceId_t devId, const QString& adapterId)
 {
     if (!_devices.contains(devId))
     {
         _devices[devId] = Device(devId);
+        if (!adapterId.isEmpty())
+        {
+            _devices[devId].setAdapterId(adapterId);
+        }
         emit deviceListChanged();
     }
 }
@@ -388,7 +400,7 @@ void SettingsModel::reconcileDevicesWithAdapters()
             seenDeviceIds.insert(devId);
 
             const bool alreadyKnownDevice = _devices.contains(devId);
-            addDevice(devId);
+            addDevice(devId, adapterId);
             if (deviceSettings(devId)->adapterId() != adapterId)
             {
                 deviceSettings(devId)->setAdapterId(adapterId);

--- a/src/models/settingsmodel.h
+++ b/src/models/settingsmodel.h
@@ -27,7 +27,7 @@ public:
     bool absoluteTimes();
 
     deviceId_t addNewDevice();
-    void addDevice(deviceId_t devId);
+    void addDevice(deviceId_t devId, const QString& adapterId = QString());
     void removeDevice(deviceId_t devId);
     void removeAllDevice();
     bool hasDevice(deviceId_t devId) const;

--- a/src/models/settingsmodel.h
+++ b/src/models/settingsmodel.h
@@ -27,7 +27,7 @@ public:
     bool absoluteTimes();
 
     deviceId_t addNewDevice();
-    void addDevice(deviceId_t devId, const QString& adapterId = QString());
+    void addDevice(deviceId_t devId, const QString& adapterId = QString(), const QString& name = QString());
     void removeDevice(deviceId_t devId);
     void removeAllDevice();
     bool hasDevice(deviceId_t devId) const;

--- a/src/util/expressionstatus.cpp
+++ b/src/util/expressionstatus.cpp
@@ -16,6 +16,7 @@ ExpressionStatus::ExpressionStatus(GraphDataModel* pGraphDataModel, SettingsMode
 {
     connect(_pGraphDataModel, &GraphDataModel::added, this, &ExpressionStatus::handleExpressionsChanged);
     connect(_pGraphDataModel, &GraphDataModel::expressionChanged, this, &ExpressionStatus::handleExpressionsChanged);
+    connect(_pSettingsModel, &SettingsModel::deviceListChanged, this, &ExpressionStatus::handleDeviceListChanged);
 
     connect(&_checker, &ExpressionChecker::resultsReady, this, &ExpressionStatus::handleResultReady);
 }
@@ -68,6 +69,15 @@ void ExpressionStatus::handleExpressionsChanged(GraphIdx graphIdx)
     if (bStartChecker)
     {
         verifyExpression(expression, _pSettingsModel->deviceList());
+    }
+}
+
+void ExpressionStatus::handleDeviceListChanged()
+{
+    const qint32 count = _pGraphDataModel->size();
+    for (qint32 idx = 0; idx < count; idx++)
+    {
+        handleExpressionsChanged(GraphIdx(idx));
     }
 }
 

--- a/src/util/expressionstatus.h
+++ b/src/util/expressionstatus.h
@@ -23,6 +23,7 @@ public:
 private slots:
     void handleResultReady(bool valid);
     void handleExpressionsChanged(GraphIdx graphIdx);
+    void handleDeviceListChanged();
 
 private:
     void verifyExpression(QString const& expression, QList<deviceId_t> const& deviceIdList);

--- a/tests/ProtocolAdapter/tst_adapterhub.cpp
+++ b/tests/ProtocolAdapter/tst_adapterhub.cpp
@@ -53,6 +53,10 @@ public:
             emit adapterReady();
         }
     }
+    void initAdapter() override
+    {
+        _initAdapterCalls++;
+    }
 
     int readDataCalls() const
     {
@@ -61,6 +65,10 @@ public:
     int stopSessionCalls() const
     {
         return _stopSessionCalls;
+    }
+    int initAdapterCalls() const
+    {
+        return _initAdapterCalls;
     }
 
     void setEmitsAdapterReadySynchronouslyOnStop(bool emitsSynchronously)
@@ -72,6 +80,7 @@ private:
     FakeState _state;
     int _readDataCalls = 0;
     int _stopSessionCalls = 0;
+    int _initAdapterCalls = 0;
     bool _emitsAdapterReadySynchronouslyOnStop = false;
 };
 
@@ -278,6 +287,40 @@ void TestAdapterHub::stopSessionWaitsForAllAdaptersWhenOneStopsSynchronously()
     QCOMPARE(pAsynchronous->stopSessionCalls(), 1);
 
     emit pAsynchronous->adapterReady();
+    QCOMPARE(readySpy.count(), 1);
+}
+
+/*!
+ * \brief F13 regression test: a mixed idle/ready fleet must not deadlock the start path.
+ *
+ * Reproduces the exact scenario from the multi-device coherence audit: one adapter has
+ * crashed back to IDLE while a sibling is still AWAITING_CONFIG. Under the old fleet-wide
+ * isAdapterIdle()/isAdapterReady() predicates neither ever becomes true for this mix, so
+ * initAdapter() was never called and adapterReady() never fired. initAdapter() must instead
+ * restart only the idle manager and leave the ready one untouched, and the hub must still
+ * become ready once that one manager reports back.
+ */
+void TestAdapterHub::initAdapterReinitializesOnlyIdleManagers()
+{
+    AdapterHub hub;
+    auto* pIdle = new FakeAdapterManager(QStringLiteral("modbus"), FakeAdapterManager::FakeState::Idle, &hub);
+    auto* pReady =
+      new FakeAdapterManager(QStringLiteral("iec104"), FakeAdapterManager::FakeState::AwaitingConfig, &hub);
+    hub._adapterManagers.insert(QStringLiteral("modbus"), pIdle);
+    hub._adapterManagers.insert(QStringLiteral("iec104"), pReady);
+    hub.connectManager(pIdle, QStringLiteral("modbus"));
+    hub.connectManager(pReady, QStringLiteral("iec104"));
+
+    QSignalSpy readySpy(&hub, &AdapterHub::adapterReady);
+
+    hub.initAdapter();
+
+    QCOMPARE(pIdle->initAdapterCalls(), 1);
+    QCOMPARE(pReady->initAdapterCalls(), 0);
+
+    /* Only the previously-idle adapter needs to report back - the already-ready sibling was
+       never added to _pendingReadyAdapters, so it doesn't need to re-report. */
+    hub.onManagerAdapterReady(QStringLiteral("modbus"));
     QCOMPARE(readySpy.count(), 1);
 }
 

--- a/tests/ProtocolAdapter/tst_adapterhub.h
+++ b/tests/ProtocolAdapter/tst_adapterhub.h
@@ -15,6 +15,7 @@ private slots:
     void stopSessionForceStopsMidHandshakeAdaptersWithoutWaiting();
     void stopSessionPurgesPendingStartForForceStoppedAdapters();
     void stopSessionWaitsForAllAdaptersWhenOneStopsSynchronously();
+    void initAdapterReinitializesOnlyIdleManagers();
 };
 
 #endif // TST_ADAPTERHUB_H

--- a/tests/communication/tst_adapterpoll.cpp
+++ b/tests/communication/tst_adapterpoll.cpp
@@ -22,10 +22,6 @@ public:
     {
         return _mockReady;
     }
-    bool isAdapterIdle() const override
-    {
-        return _mockIdle;
-    }
     void startSession(const QString& adapterId, const QStringList& expressions) override
     {
         _startCalls.append({ adapterId, expressions });
@@ -60,7 +56,6 @@ public:
     }
 
     bool _mockReady{ false };
-    bool _mockIdle{ false };
     QList<QPair<QString, QStringList>> _startCalls;
     int _initCount{ 0 };
     int _stopCount{ 0 };
@@ -100,17 +95,19 @@ void TestAdapterPoll::startCommunicationWhenAdapterReady()
     QVERIFY(s_pPoll->isActive());
 }
 
-void TestAdapterPoll::startCommunicationWhenAdapterIdle()
+void TestAdapterPoll::startCommunicationWhenAdapterNotReady()
 {
+    /* AdapterPoll no longer distinguishes "idle" from "mid-init" — it unconditionally asks the
+       hub to get ready and lets AdapterHub decide, per-manager, what actually needs restarting
+       (see F13 in the multi-device coherence audit). */
     s_pMockHub->_mockReady = false;
-    s_pMockHub->_mockIdle = true;
 
     QList<DataPoint> registers{ DataPoint(QStringLiteral("${h0}"), 1) };
     s_pPoll->startCommunication(registers);
 
     /* startSession not called yet — waiting for adapterReady */
     QCOMPARE(s_pMockHub->_startCalls.size(), 0);
-    /* initAdapter called to kick off the process */
+    /* initAdapter called unconditionally to ask the hub to get ready */
     QCOMPARE(s_pMockHub->_initCount, 1);
 
     s_pMockHub->triggerAdapterReady();
@@ -120,29 +117,9 @@ void TestAdapterPoll::startCommunicationWhenAdapterIdle()
     QCOMPARE(s_pMockHub->_startCalls[0].second, QStringList{ QStringLiteral("${h0}") });
 }
 
-void TestAdapterPoll::startCommunicationWhenAdapterInitializing()
-{
-    s_pMockHub->_mockReady = false;
-    s_pMockHub->_mockIdle = false;
-
-    QList<DataPoint> registers{ DataPoint(QStringLiteral("${h1}"), 1) };
-    s_pPoll->startCommunication(registers);
-
-    /* Neither startSession nor initAdapter called — adapter is mid-init */
-    QCOMPARE(s_pMockHub->_startCalls.size(), 0);
-    QCOMPARE(s_pMockHub->_initCount, 0);
-
-    s_pMockHub->triggerAdapterReady();
-
-    QCOMPARE(s_pMockHub->_startCalls.size(), 1);
-    QCOMPARE(s_pMockHub->_startCalls[0].first, QStringLiteral("modbus"));
-    QCOMPARE(s_pMockHub->_startCalls[0].second, QStringList{ QStringLiteral("${h1}") });
-}
-
 void TestAdapterPoll::doubleStartCommunicationWhileInitializing()
 {
     s_pMockHub->_mockReady = false;
-    s_pMockHub->_mockIdle = false;
 
     QList<DataPoint> registers1{ DataPoint(QStringLiteral("${h0}"), 1) };
     QList<DataPoint> registers2{ DataPoint(QStringLiteral("${h1}"), 1) };
@@ -161,7 +138,6 @@ void TestAdapterPoll::doubleStartCommunicationWhileInitializing()
 void TestAdapterPoll::stopCommunicationClearsPendingState()
 {
     s_pMockHub->_mockReady = false;
-    s_pMockHub->_mockIdle = true;
 
     QList<DataPoint> registers{ DataPoint(QStringLiteral("${h0}"), 1) };
     s_pPoll->startCommunication(registers);
@@ -179,7 +155,6 @@ void TestAdapterPoll::stopCommunicationClearsPendingState()
 void TestAdapterPoll::stopCommunicationAllowsNewWaitAfterRestart()
 {
     s_pMockHub->_mockReady = false;
-    s_pMockHub->_mockIdle = false;
 
     QList<DataPoint> registers1{ DataPoint(QStringLiteral("${h0}"), 1) };
     s_pPoll->startCommunication(registers1);
@@ -283,7 +258,6 @@ void TestAdapterPoll::sessionErrorWhileWaitingForAdapterEmitsCommunicationError(
     /* A session error while still waiting for the adapter to become ready (e.g. it failed to
        initialize) must be surfaced exactly like an error during an active session. */
     s_pMockHub->_mockReady = false;
-    s_pMockHub->_mockIdle = true;
 
     QList<DataPoint> registers{ DataPoint(QStringLiteral("${h0}"), 1) };
     s_pPoll->startCommunication(registers);

--- a/tests/communication/tst_adapterpoll.h
+++ b/tests/communication/tst_adapterpoll.h
@@ -11,8 +11,7 @@ private slots:
     void cleanup();
 
     void startCommunicationWhenAdapterReady();
-    void startCommunicationWhenAdapterIdle();
-    void startCommunicationWhenAdapterInitializing();
+    void startCommunicationWhenAdapterNotReady();
     void doubleStartCommunicationWhileInitializing();
     void stopCommunicationClearsPendingState();
     void stopCommunicationAllowsNewWaitAfterRestart();

--- a/tests/dialogs/mockadapterhub.h
+++ b/tests/dialogs/mockadapterhub.h
@@ -50,18 +50,6 @@ public:
         return true;
     }
 
-    bool isAdapterIdle() const override
-    {
-        for (const AdapterManager* pManager : _managers)
-        {
-            if (!pManager->isAdapterIdle())
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
 private:
     QMap<QString, AdapterManager*> _managers;
 };

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -421,6 +421,35 @@ void TestAddRegisterWidget::deviceComboRefreshesLiveOnDeviceAdded()
     QCOMPARE(_pRegWidget->_pUi->cmbDevice->itemText(1), QString("Device %1").arg(simDeviceId));
 }
 
+void TestAddRegisterWidget::deviceAddedToEmptyListAppliesConfiguredAdapter()
+{
+    _settingsModel.setAdapterDataPointSchema("sim", buildSimRegisterSchema());
+    QJsonObject describeResult;
+    describeResult["name"] = QStringLiteral("Simulator");
+    _settingsModel.updateAdapterFromDescribe(QStringLiteral("sim"), describeResult);
+    _pMockSimAdapterManager = new MockAdapterManager(&_settingsModel, QStringLiteral("sim"));
+    _pMockHub->addManager(QStringLiteral("sim"), _pMockSimAdapterManager);
+
+    /* Start from an empty device list, so the device added below becomes the selected one
+     * and the combo refresh has to build its address form from the sim adapter. */
+    _settingsModel.removeAllDevice();
+    delete _pRegWidget;
+    _pRegWidget = new AddRegisterWidget(&_settingsModel, _pMockHub);
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->count(), 0);
+
+    const deviceId_t simDeviceId = Device::cFirstDeviceId;
+    _settingsModel.addDevice(simDeviceId, QStringLiteral("sim"));
+
+    /* The adapter must already be assigned when deviceListChanged() arrives: assigning it
+     * afterwards left the widget showing Device's default ("modbus") adapter instead. */
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->count(), 1);
+    QCOMPARE(_pRegWidget->_pUi->lblProtocol->text(), QStringLiteral("Protocol: Simulator"));
+    QVERIFY(_pRegWidget->_addressSchema["properties"].toObject().contains(QStringLiteral("channel")));
+    const QJsonObject addressValues = _pRegWidget->_pAddressForm->values();
+    QCOMPARE(addressValues.value("channel").toInt(), 3);
+    QVERIFY(_pRegWidget->_pUi->btnAdd->isEnabled());
+}
+
 void TestAddRegisterWidget::deviceComboDisablesAddWhenLastDeviceRemoved()
 {
     _settingsModel.removeDevice(Device::cFirstDeviceId);

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -401,6 +401,34 @@ void TestAddRegisterWidget::btnAddDisabledWhenSelectedDeviceAdapterUnavailable()
     QVERIFY(_pRegWidget->_pUi->btnAdd->isEnabled());
 }
 
+void TestAddRegisterWidget::deviceComboRefreshesLiveOnDeviceAdded()
+{
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->count(), 1);
+
+    /* Mirrors addSimAdapter()'s setup, but without deleting/reconstructing _pRegWidget:
+     * the point of this test is that the combo now picks up the new device on its own. */
+    _settingsModel.setAdapterDataPointSchema("sim", buildSimRegisterSchema());
+    QJsonObject describeResult;
+    describeResult["name"] = QStringLiteral("Simulator");
+    _settingsModel.updateAdapterFromDescribe(QStringLiteral("sim"), describeResult);
+    _pMockSimAdapterManager = new MockAdapterManager(&_settingsModel, QStringLiteral("sim"));
+    _pMockHub->addManager(QStringLiteral("sim"), _pMockSimAdapterManager);
+
+    const deviceId_t simDeviceId = _settingsModel.addNewDevice();
+    _settingsModel.deviceSettings(simDeviceId)->setAdapterId(QStringLiteral("sim"));
+
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->count(), 2);
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->itemText(1), QString("Device %1").arg(simDeviceId));
+}
+
+void TestAddRegisterWidget::deviceComboDisablesAddWhenLastDeviceRemoved()
+{
+    _settingsModel.removeDevice(Device::cFirstDeviceId);
+
+    QCOMPARE(_pRegWidget->_pUi->cmbDevice->count(), 0);
+    QVERIFY(!_pRegWidget->_pUi->btnAdd->isEnabled());
+}
+
 void TestAddRegisterWidget::clickAdd()
 {
     QTest::mouseClick(_pRegWidget->_pUi->btnAdd, Qt::LeftButton);

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -78,6 +78,8 @@ private slots:
     void switchToLargerSchemaWhileMenuOpenShowsAllFields();
     void buildExpressionRoutedToSelectedDevice();
     void btnAddDisabledWhenSelectedDeviceAdapterUnavailable();
+    void deviceComboRefreshesLiveOnDeviceAdded();
+    void deviceComboDisablesAddWhenLastDeviceRemoved();
 
 private:
     void clickAdd();

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -79,6 +79,7 @@ private slots:
     void buildExpressionRoutedToSelectedDevice();
     void btnAddDisabledWhenSelectedDeviceAdapterUnavailable();
     void deviceComboRefreshesLiveOnDeviceAdded();
+    void deviceAddedToEmptyListAppliesConfiguredAdapter();
     void deviceComboDisablesAddWhenLastDeviceRemoved();
 
 private:

--- a/tests/importexport/tst_projectfilehandler.cpp
+++ b/tests/importexport/tst_projectfilehandler.cpp
@@ -154,6 +154,47 @@ void TestProjectFileHandler::applyDeviceSettingsAppliesName()
 }
 
 /*!
+ * \brief The device name is applied before the model announces the new device.
+ */
+void TestProjectFileHandler::applyDeviceSettingsAppliesNameBeforeNotifying()
+{
+    QJsonArray adapters;
+    QJsonObject adapter;
+    adapter["type"] = "modbus";
+    adapter["settings"] = QJsonObject();
+    adapters.append(adapter);
+
+    QJsonArray devices;
+    QJsonObject dev;
+    dev["id"] = 1;
+    dev["name"] = "Pump";
+    dev["adapterId"] = 0;
+    QJsonObject adapterRef;
+    adapterRef["type"] = "modbus";
+    dev["adapter"] = adapterRef;
+    devices.append(dev);
+
+    const QString path = writeTempProjectFile(adapters, devices);
+    QVERIFY(!path.isEmpty());
+
+    GuiModel guiModel;
+    SettingsModel settingsModel;
+    GraphDataModel graphDataModel(&settingsModel);
+    ProjectFileHandler handler(&guiModel, &settingsModel, &graphDataModel);
+
+    DeviceNameProbe probe(&settingsModel, 1);
+
+    handler.openProjectFile(path);
+
+    /* Setting the name after addDevice() left every observer of the load with the
+     * placeholder name the Device constructor assigns. */
+    QVERIFY(!probe.names.isEmpty());
+    QCOMPARE(probe.names.first(), QStringLiteral("Pump"));
+
+    QFile::remove(path);
+}
+
+/*!
  * \brief Devices referencing different adapters each get the correct adapterId string.
  */
 void TestProjectFileHandler::applyDeviceSettingsMultipleAdapters()

--- a/tests/importexport/tst_projectfilehandler.h
+++ b/tests/importexport/tst_projectfilehandler.h
@@ -1,7 +1,44 @@
 #ifndef TST_PROJECTFILEHANDLER_H
 #define TST_PROJECTFILEHANDLER_H
 
+#include "models/settingsmodel.h"
+
 #include <QObject>
+#include <QStringList>
+
+/*!
+ * \brief Records a device's name as it stands each time deviceListChanged() is emitted.
+ *
+ * Observers rebuild their view of the device list from inside that signal, so what they
+ * read there is what ends up on screen. Checking the name only once the load has finished
+ * would pass even when the name was applied too late to reach them.
+ */
+class DeviceNameProbe : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit DeviceNameProbe(SettingsModel* pSettingsModel, deviceId_t devId, QObject* parent = nullptr)
+        : QObject(parent), _pSettingsModel(pSettingsModel), _devId(devId)
+    {
+        connect(_pSettingsModel, &SettingsModel::deviceListChanged, this, &DeviceNameProbe::recordName);
+    }
+
+    QStringList names;
+
+private slots:
+    void recordName()
+    {
+        if (_pSettingsModel->hasDevice(_devId))
+        {
+            names.append(_pSettingsModel->deviceSettings(_devId)->name());
+        }
+    }
+
+private:
+    SettingsModel* _pSettingsModel;
+    deviceId_t _devId;
+};
 
 class TestProjectFileHandler : public QObject
 {
@@ -12,6 +49,7 @@ private slots:
 
     void applyDeviceSettingsAppliesAdapterId();
     void applyDeviceSettingsAppliesName();
+    void applyDeviceSettingsAppliesNameBeforeNotifying();
     void applyDeviceSettingsMultipleAdapters();
     void applyDeviceSettingsEmptyListClearsModel();
     void applyDeviceSettingsClearsPreviousDevices();

--- a/tests/util/tst_expressionstatus.cpp
+++ b/tests/util/tst_expressionstatus.cpp
@@ -92,4 +92,19 @@ void TestExpressionStatus::afterRemoval_subsequentExpressionChange_setsCorrectSt
     QCOMPARE(_pGraphDataModel->expressionState(GraphIdx(0)), ExpressionState::SYNTAX_ERROR);
 }
 
+void TestExpressionStatus::deviceRemoved_revalidatesReferencingExpression()
+{
+    const deviceId_t secondDeviceId = _pSettingsModel->addNewDevice();
+
+    ExpressionStatus status(_pGraphDataModel, _pSettingsModel);
+
+    _pGraphDataModel->add();
+    _pGraphDataModel->setExpression(GraphIdx(0), QString("${40001@%1}").arg(secondDeviceId));
+    QCOMPARE(_pGraphDataModel->expressionState(GraphIdx(0)), ExpressionState::VALID);
+
+    _pSettingsModel->removeDevice(secondDeviceId);
+
+    QCOMPARE(_pGraphDataModel->expressionState(GraphIdx(0)), ExpressionState::UNKNOWN_DEVICE);
+}
+
 QTEST_GUILESS_MAIN(TestExpressionStatus)

--- a/tests/util/tst_expressionstatus.h
+++ b/tests/util/tst_expressionstatus.h
@@ -19,6 +19,7 @@ private slots:
     void syntaxErrorExpression_setsSyntaxErrorState();
     void registerExpression_noDevice_setsUnknownDeviceState();
     void afterRemoval_subsequentExpressionChange_setsCorrectState();
+    void deviceRemoved_revalidatesReferencingExpression();
 
 private:
     GraphDataModel* _pGraphDataModel = nullptr;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adapter reconnection now preserves active sessions while restarting only idle or failed connections.
  - Device selections update automatically when devices are added or removed.
  - Add actions are disabled when no devices remain.
  - Expressions referencing removed devices are revalidated and correctly marked as unknown.
  - Adapter readiness and restart behaviour are now more reliable during communication.
  - Device names and adapter assignments are applied correctly during creation and project loading.

- **Tests**
  - Added coverage for mixed adapter states, live device-list updates, expression revalidation, and project loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->