### PR TITLE
Close Addregister menu on add

### DIFF
--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -227,6 +227,11 @@ void AddRegisterWidget::resizeContainingMenu()
  * RegisterDialog does for btnAdd), clicking this widget's own "Add" button doesn't trigger
  * the QWidgetAction itself, so QMenu never closes on its own. Close it explicitly so adding
  * a register behaves like any other menu action.
+ *
+ * Only called from onBuildExpressionResult(), which runs on a later event loop turn than the
+ * "Add" button click that triggered the request (buildExpression() replies asynchronously over
+ * the adapter subprocess IPC channel) - closing the menu here never nests inside btnAdd's own
+ * click handling.
  */
 void AddRegisterWidget::closeContainingMenu()
 {

--- a/src/dialogs/addregisterwidget.cpp
+++ b/src/dialogs/addregisterwidget.cpp
@@ -221,6 +221,25 @@ void AddRegisterWidget::resizeContainingMenu()
 }
 
 /*!
+ * \brief Closes the enclosing popup menu, if any, after a register was successfully added.
+ *
+ * When hosted as a QWidgetAction's default widget inside a QToolButton's popup menu (as
+ * RegisterDialog does for btnAdd), clicking this widget's own "Add" button doesn't trigger
+ * the QWidgetAction itself, so QMenu never closes on its own. Close it explicitly so adding
+ * a register behaves like any other menu action.
+ */
+void AddRegisterWidget::closeContainingMenu()
+{
+    auto* menu = qobject_cast<QMenu*>(window());
+    if (menu == nullptr)
+    {
+        return;
+    }
+
+    menu->close();
+}
+
+/*!
  * \brief Returns whether the currently selected device's adapter has a live manager.
  */
 bool AddRegisterWidget::isSelectionUsable() const
@@ -284,7 +303,7 @@ void AddRegisterWidget::onBuildExpressionResult(const QString& expression)
 
     resetFields();
     rebuildAddressForm();
-    resizeContainingMenu();
+    closeContainingMenu();
 }
 
 void AddRegisterWidget::resetFields()

--- a/src/dialogs/addregisterwidget.h
+++ b/src/dialogs/addregisterwidget.h
@@ -44,6 +44,7 @@ private:
     void applyDevice(deviceId_t deviceId);
     void rebuildAddressForm();
     void resizeContainingMenu();
+    void closeContainingMenu();
     bool isSelectionUsable() const;
     deviceId_t selectedDeviceId() const;
     QJsonObject buildSchema(const AdapterData* adapterData) const;

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -476,6 +476,27 @@ void TestAddRegisterWidget::addRegisterClosesContainingMenu()
     QVERIFY(!menu.isVisible());
 }
 
+void TestAddRegisterWidget::emptyExpressionResponseLeavesContainingMenuOpen()
+{
+    /* See switchDeviceWhileMenuOpenResizesPopup for why ownership is handed off up front. */
+    AddRegisterWidget* pWidget = _pRegWidget;
+    _pRegWidget = nullptr;
+
+    QMenu menu;
+    auto* action = new QWidgetAction(&menu);
+    action->setDefaultWidget(pWidget);
+    menu.addAction(action);
+
+    menu.show();
+
+    QTest::mouseClick(pWidget->_pUi->btnAdd, Qt::LeftButton);
+    _pMockAdapterManager->injectBuildExpressionResult(QString());
+
+    QVERIFY(menu.isVisible());
+
+    menu.hide();
+}
+
 void TestAddRegisterWidget::clickAdd()
 {
     QTest::mouseClick(_pRegWidget->_pUi->btnAdd, Qt::LeftButton);

--- a/tests/dialogs/tst_addregisterwidget.cpp
+++ b/tests/dialogs/tst_addregisterwidget.cpp
@@ -456,6 +456,26 @@ void TestAddRegisterWidget::deviceComboDisablesAddWhenLastDeviceRemoved()
     QVERIFY(!_pRegWidget->_pUi->btnAdd->isEnabled());
 }
 
+void TestAddRegisterWidget::addRegisterClosesContainingMenu()
+{
+    /* See switchDeviceWhileMenuOpenResizesPopup for why ownership is handed off up front. */
+    AddRegisterWidget* pWidget = _pRegWidget;
+    _pRegWidget = nullptr;
+
+    QMenu menu;
+    auto* action = new QWidgetAction(&menu);
+    action->setDefaultWidget(pWidget);
+    menu.addAction(action);
+
+    menu.show();
+    QVERIFY(menu.isVisible());
+
+    QTest::mouseClick(pWidget->_pUi->btnAdd, Qt::LeftButton);
+    _pMockAdapterManager->injectBuildExpressionResult(QStringLiteral("${h0}"));
+
+    QVERIFY(!menu.isVisible());
+}
+
 void TestAddRegisterWidget::clickAdd()
 {
     QTest::mouseClick(_pRegWidget->_pUi->btnAdd, Qt::LeftButton);

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -82,6 +82,7 @@ private slots:
     void deviceAddedToEmptyListAppliesConfiguredAdapter();
     void deviceComboDisablesAddWhenLastDeviceRemoved();
     void addRegisterClosesContainingMenu();
+    void emptyExpressionResponseLeavesContainingMenuOpen();
 
 private:
     void clickAdd();

--- a/tests/dialogs/tst_addregisterwidget.h
+++ b/tests/dialogs/tst_addregisterwidget.h
@@ -81,6 +81,7 @@ private slots:
     void deviceComboRefreshesLiveOnDeviceAdded();
     void deviceAddedToEmptyListAppliesConfiguredAdapter();
     void deviceComboDisablesAddWhenLastDeviceRemoved();
+    void addRegisterClosesContainingMenu();
 
 private:
     void clickAdd();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device lists now refresh automatically when devices are added or removed.
  * The current device selection is preserved where possible during refresh.
  * The Add action is disabled when no devices are available.

* **Bug Fixes**
  * Menus now close after successful register configuration.
  * Menus remain open when no valid expression is returned.

* **Tests**
  * Added coverage for device updates, adapter selection, and menu behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->