### PR TITLE
Show devices instead of adapters in expression help selector

### DIFF
--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -51,7 +51,7 @@ ExpressionsDialog::ExpressionsDialog(GraphDataModel* pGraphDataModel,
 
     connect(&_expressionChecker, &ExpressionChecker::resultsReady, this, &ExpressionsDialog::handleResultReady);
 
-    populateHelpAdapters();
+    populateHelpDevices();
 
     _pUi->tblExpressionInput->setRowCount(0);
     _pUi->tblExpressionInput->setColumnCount(2);
@@ -178,40 +178,42 @@ void ExpressionsDialog::handleExpressionHelpResult(const QString& helpText)
 }
 
 /*!
- * \brief Fill the help adapter selector and request help text for the initial selection.
+ * \brief Fill the help device selector and request help text for the initial selection.
  *
- * The selector is hidden when fewer than two adapters are available.
+ * Each entry represents a configured device, labeled with its name, protocol and id.
+ * The selector is hidden when fewer than two devices are available.
  */
-void ExpressionsDialog::populateHelpAdapters()
+void ExpressionsDialog::populateHelpDevices()
 {
-    if (_pAdapterHub == nullptr)
+    if (_pAdapterHub == nullptr || _pSettingsModel == nullptr)
     {
-        _pUi->widgetHelpAdapter->setVisible(false);
+        _pUi->widgetHelpDevice->setVisible(false);
         return;
     }
 
-    const QStringList adapterIds = _pAdapterHub->adapterIds();
-    for (const QString& adapterId : adapterIds)
+    const QList<deviceId_t> deviceIds = _pSettingsModel->deviceList();
+    for (deviceId_t deviceId : deviceIds)
     {
-        QString label;
-        if (_pSettingsModel != nullptr)
+        Device* pDevice = _pSettingsModel->deviceSettings(deviceId);
+        const QString adapterId = pDevice->adapterId();
+
+        QString protocolLabel = _pSettingsModel->adapterData(adapterId)->name();
+        if (protocolLabel.isEmpty())
         {
-            label = _pSettingsModel->adapterData(adapterId)->name();
+            protocolLabel = adapterId;
         }
-        if (label.isEmpty())
-        {
-            label = adapterId;
-        }
-        _pUi->cmbHelpAdapter->addItem(label, adapterId);
+
+        const QString label = QStringLiteral("%1 (%2) [%3]").arg(pDevice->name(), protocolLabel).arg(deviceId);
+        _pUi->cmbHelpDevice->addItem(label, adapterId);
     }
-    _pUi->widgetHelpAdapter->setVisible(adapterIds.size() > 1);
+    _pUi->widgetHelpDevice->setVisible(deviceIds.size() > 1);
 
     /* Connect after populating to avoid spurious slot calls during addItem */
-    connect(_pUi->cmbHelpAdapter, &QComboBox::currentIndexChanged, this, &ExpressionsDialog::onHelpAdapterChanged);
+    connect(_pUi->cmbHelpDevice, &QComboBox::currentIndexChanged, this, &ExpressionsDialog::onHelpDeviceChanged);
 
-    if (!adapterIds.isEmpty())
+    if (!deviceIds.isEmpty())
     {
-        requestHelpForAdapter(_pUi->cmbHelpAdapter->currentData().toString());
+        requestHelpForAdapter(_pUi->cmbHelpDevice->currentData().toString());
     }
 }
 
@@ -220,10 +222,18 @@ void ExpressionsDialog::populateHelpAdapters()
  *
  * Any pending help connection to a previously selected adapter is dropped so a
  * late response cannot overwrite the newly selected adapter's help text.
+ * A no-op if the given adapter is already the one being shown, since multiple
+ * devices can share the same adapter and switching between them should not
+ * flicker the help text or trigger a redundant request.
  * \param adapterId Identifier of the adapter to request help from.
  */
 void ExpressionsDialog::requestHelpForAdapter(const QString& adapterId)
 {
+    if (_pHelpManager != nullptr && _pHelpManager->adapterId() == adapterId)
+    {
+        return;
+    }
+
     if (_pHelpManager != nullptr)
     {
         QObject::disconnect(_pHelpManager, &AdapterManager::expressionHelpResult, this,
@@ -244,13 +254,13 @@ void ExpressionsDialog::requestHelpForAdapter(const QString& adapterId)
 }
 
 /*!
- * \brief Show the expression help of the newly selected adapter.
+ * \brief Show the expression help of the newly selected device's adapter.
  * \param index Index of the newly selected combo box entry (unused).
  */
-void ExpressionsDialog::onHelpAdapterChanged(int index)
+void ExpressionsDialog::onHelpDeviceChanged(int index)
 {
     Q_UNUSED(index);
-    requestHelpForAdapter(_pUi->cmbHelpAdapter->currentData().toString());
+    requestHelpForAdapter(_pUi->cmbHelpDevice->currentData().toString());
 }
 
 /*!

--- a/src/dialogs/expressionsdialog.h
+++ b/src/dialogs/expressionsdialog.h
@@ -38,11 +38,11 @@ private slots:
     void handleResultReady(bool valid);
     void handleExpressionHelpResult(const QString& helpText);
     void handleDescribeDataPointResult(const QJsonObject& result);
-    void onHelpAdapterChanged(int index);
+    void onHelpDeviceChanged(int index);
 
 private:
     void startNextDescribe();
-    void populateHelpAdapters();
+    void populateHelpDevices();
     void requestHelpForAdapter(const QString& adapterId);
     AdapterManager* managerForDescribeRow(qint32 row) const;
     void setDescribeRowText(qint32 row, const QString& text);

--- a/src/dialogs/expressionsdialog.ui
+++ b/src/dialogs/expressionsdialog.ui
@@ -187,7 +187,7 @@
     <widget class="QWidget" name="widgetInfo" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <property name="spacing">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="leftMargin">
        <number>0</number>
@@ -202,7 +202,7 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QWidget" name="widgetHelpAdapter" native="true">
+       <widget class="QWidget" name="widgetHelpDevice" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <property name="leftMargin">
           <number>0</number>
@@ -217,14 +217,14 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="lblHelpAdapter">
+          <widget class="QLabel" name="lblHelpDevice">
            <property name="text">
-            <string>Adapter</string>
+            <string>Device</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="cmbHelpAdapter"/>
+          <widget class="QComboBox" name="cmbHelpDevice"/>
          </item>
          <item>
           <spacer name="horizontalSpacer">
@@ -254,7 +254,7 @@
          <string/>
         </property>
         <property name="textFormat">
-         <enum>Qt::RichText</enum>
+         <enum>Qt::TextFormat::RichText</enum>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/tests/dialogs/tst_expressionsdialog.cpp
+++ b/tests/dialogs/tst_expressionsdialog.cpp
@@ -220,40 +220,57 @@ void TestExpressionsDialog::describeShowsInvalidDeviceMessage()
     QCOMPARE(_pMockAdapterManager->describeCalls.size(), 1);
 }
 
-void TestExpressionsDialog::helpComboHiddenWithSingleAdapter()
+void TestExpressionsDialog::helpComboHiddenWithSingleDevice()
 {
     /* Use isHidden(): the surrounding info panel (widgetInfo) starts collapsed,
      * so visibility relative to the dialog is always false */
-    auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpAdapter");
+    auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpDevice");
     QVERIFY(pHelpWidget != nullptr);
     QVERIFY(pHelpWidget->isHidden());
 }
 
-void TestExpressionsDialog::helpComboVisibleWithTwoAdapters()
+void TestExpressionsDialog::helpComboVisibleWithTwoDevices()
 {
+    _pSettingsModel->deviceSettings(2)->setAdapterId("sim");
     addSimAdapter();
     recreateDialog();
 
-    auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpAdapter");
+    auto* pHelpWidget = _pDialog->findChild<QWidget*>("widgetHelpDevice");
     QVERIFY(pHelpWidget != nullptr);
     QVERIFY(!pHelpWidget->isHidden());
 
-    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpAdapter");
+    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpDevice");
     QVERIFY(pCombo != nullptr);
     QCOMPARE(pCombo->count(), 2);
     QCOMPARE(pCombo->itemData(0).toString(), QStringLiteral("modbus"));
     QCOMPARE(pCombo->itemData(1).toString(), QStringLiteral("sim"));
 }
 
-void TestExpressionsDialog::helpRoutedToSelectedAdapter()
+void TestExpressionsDialog::helpComboShowsNameProtocolAndId()
 {
+    _pSettingsModel->deviceSettings(2)->setAdapterId("sim");
+    _pSettingsModel->deviceSettings(2)->setName(QStringLiteral("PLC-North"));
+    addSimAdapter();
+    recreateDialog();
+
+    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpDevice");
+    QVERIFY(pCombo != nullptr);
+    QCOMPARE(pCombo->count(), 2);
+    /* Label format: "<device name> (<protocol>) [<device id>]" */
+    QCOMPARE(pCombo->itemText(0), QStringLiteral("Device 1 (modbus) [1]"));
+    QCOMPARE(pCombo->itemText(1), QStringLiteral("PLC-North (sim) [2]"));
+}
+
+void TestExpressionsDialog::helpRoutedToSelectedDevice()
+{
+    _pSettingsModel->deviceSettings(2)->setAdapterId("sim");
     MockAdapterManager* pSimManager = addSimAdapter();
     recreateDialog();
 
     auto* pInfoLabel = _pDialog->findChild<QLabel*>("lblInfo");
     QVERIFY(pInfoLabel != nullptr);
 
-    /* The dialog requested help from the initially selected (modbus) adapter */
+    /* The dialog requested help from the initially selected device's (modbus) adapter */
     QCOMPARE(_pMockAdapterManager->helpRequestCount, 1);
     QCOMPARE(pSimManager->helpRequestCount, 0);
 
@@ -267,11 +284,11 @@ void TestExpressionsDialog::helpRoutedToSelectedAdapter()
     QVERIFY(pInfoLabel->text().indexOf(QStringLiteral("Expression Information")) <
             pInfoLabel->text().indexOf(QStringLiteral("Modbus help")));
 
-    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpAdapter");
+    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpDevice");
     QVERIFY(pCombo != nullptr);
     pCombo->setCurrentIndex(1);
 
-    /* Selecting the sim adapter clears the help text and requests its help */
+    /* Selecting the device on the sim adapter clears the help text and requests its help */
     QCOMPARE(pSimManager->helpRequestCount, 1);
     QCOMPARE(pInfoLabel->text(), QString());
 
@@ -283,6 +300,30 @@ void TestExpressionsDialog::helpRoutedToSelectedAdapter()
     _pMockAdapterManager->injectExpressionHelp(QStringLiteral("Stale modbus help"));
     QVERIFY(pInfoLabel->text().contains(QStringLiteral("Sim help")));
     QVERIFY(!pInfoLabel->text().contains(QStringLiteral("Stale modbus help")));
+}
+
+void TestExpressionsDialog::helpSwitchingBetweenDevicesOnSameAdapterSkipsRedundantRequest()
+{
+    /* Device 3 shares the modbus adapter with device 1 */
+    _pSettingsModel->deviceSettings(3)->setAdapterId("modbus");
+    recreateDialog();
+
+    auto* pInfoLabel = _pDialog->findChild<QLabel*>("lblInfo");
+    QVERIFY(pInfoLabel != nullptr);
+    QCOMPARE(_pMockAdapterManager->helpRequestCount, 1);
+
+    _pMockAdapterManager->injectExpressionHelp(QStringLiteral("Modbus help"));
+    QVERIFY(pInfoLabel->text().contains(QStringLiteral("Modbus help")));
+
+    auto* pCombo = _pDialog->findChild<QComboBox*>("cmbHelpDevice");
+    QVERIFY(pCombo != nullptr);
+    QCOMPARE(pCombo->count(), 2);
+    pCombo->setCurrentIndex(1);
+
+    /* Switching to the other device on the same adapter is a no-op: no new
+     * request is issued and the already-shown help text is not cleared */
+    QCOMPARE(_pMockAdapterManager->helpRequestCount, 1);
+    QVERIFY(pInfoLabel->text().contains(QStringLiteral("Modbus help")));
 }
 
 QTEST_MAIN(TestExpressionsDialog)

--- a/tests/dialogs/tst_expressionsdialog.h
+++ b/tests/dialogs/tst_expressionsdialog.h
@@ -78,9 +78,11 @@ private slots:
     void describeSkipsUnavailableAdapter();
     void describeSkipsIdleAdapter();
     void describeShowsInvalidDeviceMessage();
-    void helpComboHiddenWithSingleAdapter();
-    void helpComboVisibleWithTwoAdapters();
-    void helpRoutedToSelectedAdapter();
+    void helpComboHiddenWithSingleDevice();
+    void helpComboVisibleWithTwoDevices();
+    void helpComboShowsNameProtocolAndId();
+    void helpRoutedToSelectedDevice();
+    void helpSwitchingBetweenDevicesOnSameAdapterSkipsRedundantRequest();
 
 private:
     MockAdapterManager* addSimAdapter();


### PR DESCRIPTION
List each configured device (name, protocol, id) in the ExpressionsDialog help combo box instead of raw adapters, since users think in terms of devices. Selecting a device still requests help from its owning adapter, and switching between devices on the same adapter is now a no-op to avoid flickering the help text. Also widens the spacing between the selector and the info label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expression help can now be selected by configured device, with each option showing its name, protocol and ID.
  - Help selection is validated against available devices, improving accuracy when devices change.

- **Bug Fixes**
  - Switching between devices using the same adapter no longer unnecessarily reloads identical help content.
  - Existing help text is preserved when no new request is required.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->