### PR TITLE
Warn when adapter data point limit is exceeded

### DIFF
--- a/src/datahandling/datapointusage.cpp
+++ b/src/datahandling/datapointusage.cpp
@@ -1,0 +1,59 @@
+#include "datapointusage.h"
+
+#include "datahandling/expressionparser.h"
+#include "models/graphdatamodel.h"
+#include "models/settingsmodel.h"
+
+#include <utility>
+
+namespace DataPointUsage {
+
+/*!
+ * \brief Collect the expressions of every active signal.
+ * \param pGraphDataModel Model holding the configured signals.
+ * \return The expressions, in model order, of the signals that are active.
+ */
+QStringList activeExpressions(const GraphDataModel* pGraphDataModel)
+{
+    QList<GraphIdx> activeIndexList;
+    pGraphDataModel->activeGraphIndexList(activeIndexList);
+
+    QStringList expressions;
+    for (GraphIdx graphIdx : std::as_const(activeIndexList))
+    {
+        expressions.append(pGraphDataModel->expression(graphIdx));
+    }
+
+    return expressions;
+}
+
+/*!
+ * \brief Collect the data points referenced by the active signals.
+ * \param pGraphDataModel Model holding the configured signals.
+ * \return The deduplicated data points, exactly as they are requested from the adapters when
+ *         logging starts. A data point used by several signals is counted once.
+ */
+QList<DataPoint> activeDataPoints(const GraphDataModel* pGraphDataModel)
+{
+    ExpressionParser exprParser(activeExpressions(pGraphDataModel));
+    return exprParser.dataPoints();
+}
+
+/*!
+ * \brief Count data points per adapter.
+ * \param dataPoints The data points to count, typically from activeDataPoints().
+ * \param pSettingsModel Model resolving the adapter that owns a device.
+ * \return The number of data points per adapter id. Adapters without data points are absent.
+ */
+QMap<QString, int> countPerAdapter(const QList<DataPoint>& dataPoints, SettingsModel* pSettingsModel)
+{
+    QMap<QString, int> countByAdapter;
+    for (const DataPoint& dataPoint : dataPoints)
+    {
+        ++countByAdapter[pSettingsModel->adapterIdForDevice(dataPoint.deviceId())];
+    }
+
+    return countByAdapter;
+}
+
+} // namespace DataPointUsage

--- a/src/datahandling/datapointusage.cpp
+++ b/src/datahandling/datapointusage.cpp
@@ -45,7 +45,7 @@ QList<DataPoint> activeDataPoints(const GraphDataModel* pGraphDataModel)
  * \param pSettingsModel Model resolving the adapter that owns a device.
  * \return The number of data points per adapter id. Adapters without data points are absent.
  */
-QMap<QString, int> countPerAdapter(const QList<DataPoint>& dataPoints, SettingsModel* pSettingsModel)
+QMap<QString, int> countPerAdapter(const QList<DataPoint>& dataPoints, const SettingsModel* pSettingsModel)
 {
     QMap<QString, int> countByAdapter;
     for (const DataPoint& dataPoint : dataPoints)

--- a/src/datahandling/datapointusage.h
+++ b/src/datahandling/datapointusage.h
@@ -24,7 +24,7 @@ QStringList activeExpressions(const GraphDataModel* pGraphDataModel);
 
 QList<DataPoint> activeDataPoints(const GraphDataModel* pGraphDataModel);
 
-QMap<QString, int> countPerAdapter(const QList<DataPoint>& dataPoints, SettingsModel* pSettingsModel);
+QMap<QString, int> countPerAdapter(const QList<DataPoint>& dataPoints, const SettingsModel* pSettingsModel);
 
 } // namespace DataPointUsage
 

--- a/src/datahandling/datapointusage.h
+++ b/src/datahandling/datapointusage.h
@@ -1,0 +1,31 @@
+#ifndef DATAPOINTUSAGE_H
+#define DATAPOINTUSAGE_H
+
+#include "communication/datapoint.h"
+
+#include <QList>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+
+class GraphDataModel;
+class SettingsModel;
+
+/*!
+ * \brief Determines which data points the active signals actually use.
+ *
+ * The adapter enforces its own limit on the number of data points a session may read, so the
+ * counts reported here are the same ones the adapter checks: the deduplicated data points of
+ * the active signals, grouped by the adapter that owns their device.
+ */
+namespace DataPointUsage {
+
+QStringList activeExpressions(const GraphDataModel* pGraphDataModel);
+
+QList<DataPoint> activeDataPoints(const GraphDataModel* pGraphDataModel);
+
+QMap<QString, int> countPerAdapter(const QList<DataPoint>& dataPoints, SettingsModel* pSettingsModel);
+
+} // namespace DataPointUsage
+
+#endif // DATAPOINTUSAGE_H

--- a/src/datahandling/graphdatahandler.cpp
+++ b/src/datahandling/graphdatahandler.cpp
@@ -1,5 +1,6 @@
 #include "graphdatahandler.h"
 
+#include "datahandling/datapointusage.h"
 #include "datahandling/expressionparser.h"
 #include "datahandling/qmuparser.h"
 #include "models/graphdatamodel.h"
@@ -13,15 +14,9 @@
  */
 void GraphDataHandler::setupExpressions(GraphDataModel* pGraphDataModel, QList<DataPoint>& registerList)
 {
-    QStringList exprList;
-
     pGraphDataModel->activeGraphIndexList(_activeIndexList);
-    for (GraphIdx graphIdx : std::as_const(_activeIndexList))
-    {
-        exprList.append(pGraphDataModel->expression(graphIdx));
-    }
 
-    ExpressionParser exprParser(exprList);
+    ExpressionParser exprParser(DataPointUsage::activeExpressions(pGraphDataModel));
     const QList<DataPoint> regList = exprParser.dataPoints();
     const QStringList processedExpList = exprParser.processedExpressions();
 

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -4,9 +4,11 @@
 #include "ProtocolAdapter/adapterhub.h"
 #include "ProtocolAdapter/adaptermanager.h"
 #include "customwidgets/actionbuttondelegate.h"
+#include "datahandling/datapointusage.h"
 #include "dialogs/addregisterwidget.h"
 #include "dialogs/expressionsdialog.h"
 #include "dialogs/ui_registerdialog.h"
+#include "models/adapterdata.h"
 #include "models/graphdatamodel.h"
 #include "models/settingsmodel.h"
 #include "registervalueaxisdelegate.h"
@@ -102,6 +104,8 @@ RegisterDialog::RegisterDialog(GraphDataModel* pGraphDataModel,
         _registerPopupAction->setDefaultWidget(registerPopupMenu);
         _pUi->btnAdd->addAction(_registerPopupAction.get());
     }
+
+    setupDataPointLimitIndication();
 }
 
 RegisterDialog::~RegisterDialog()
@@ -263,4 +267,77 @@ void RegisterDialog::onDefaultExpressionBuilt(const QString& expression)
     {
         _pGraphDataModel->setDefaultExpression(expression);
     }
+}
+
+/*!
+ * \brief Style the data point limit warning and keep it in sync with the signal list.
+ */
+void RegisterDialog::setupDataPointLimitIndication()
+{
+    /* Adapter names come from the adapter subprocess's describe response, so treat them as
+     * untrusted: force plain text to prevent a misbehaving adapter from injecting rich-text
+     * formatting into this label. */
+    _pUi->dataPointLimitWarningLabel->setTextFormat(Qt::PlainText);
+    _pUi->dataPointLimitWarningLabel->setStyleSheet("QLabel { color: #b35900; }");
+
+    /* dataChanged covers activating a signal and editing its expression, including edits made
+     * through the expression dialog: the model emits it for the complete row. */
+    connect(_pGraphDataModel, &GraphDataModel::rowsInserted, this, &RegisterDialog::updateDataPointLimitIndication);
+    connect(_pGraphDataModel, &GraphDataModel::rowsRemoved, this, &RegisterDialog::updateDataPointLimitIndication);
+    connect(_pGraphDataModel, &GraphDataModel::modelReset, this, &RegisterDialog::updateDataPointLimitIndication);
+    connect(_pGraphDataModel, &GraphDataModel::dataChanged, this, &RegisterDialog::updateDataPointLimitIndication);
+
+    updateDataPointLimitIndication();
+}
+
+/*!
+ * \brief Build a warning message listing adapters that are asked to read more data points than
+ *  they currently allow, or an empty string when every adapter is within its limit.
+ *
+ * The limit is the adapter's reported capabilities.maxRegisters, which is only present while the
+ * adapter enforces a cap (for example when no valid license is found).
+ */
+QString RegisterDialog::dataPointLimitWarningMessage() const
+{
+    const QList<DataPoint> dataPoints = DataPointUsage::activeDataPoints(_pGraphDataModel);
+    const QMap<QString, int> countByAdapter = DataPointUsage::countPerAdapter(dataPoints, _pSettingsModel);
+
+    /* adapterData() inserts a default entry for an unknown adapterId, which would leave a phantom
+       entry behind for a warning alone. An adapter SettingsModel has never heard of cannot have
+       reported a limit either, so there is nothing to warn about. */
+    const QStringList knownAdapterIds = _pSettingsModel->adapterIds();
+
+    QStringList warnings;
+    for (auto it = countByAdapter.constBegin(); it != countByAdapter.constEnd(); ++it)
+    {
+        if (!knownAdapterIds.contains(it.key()))
+        {
+            continue;
+        }
+
+        const AdapterData* pAdapter = _pSettingsModel->adapterData(it.key());
+        const int dataPointLimit = pAdapter->maxRegisters();
+        if (it.value() > dataPointLimit)
+        {
+            const QString adapterName = pAdapter->name().isEmpty() ? it.key() : pAdapter->name();
+            warnings.append(QString("%1 allows at most %2 data point(s), but %3 are configured.")
+                              .arg(adapterName)
+                              .arg(dataPointLimit)
+                              .arg(it.value()));
+        }
+    }
+
+    return warnings.join('\n');
+}
+
+/*!
+ * \brief Show the data point limit warning while a limit is exceeded, hide it otherwise.
+ *
+ * Logging is never blocked: the adapter reports the limit itself when a session starts.
+ */
+void RegisterDialog::updateDataPointLimitIndication()
+{
+    const QString message = dataPointLimitWarningMessage();
+    _pUi->dataPointLimitWarningLabel->setText(message);
+    _pUi->dataPointLimitWarningLabel->setVisible(!message.isEmpty());
 }

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -41,10 +41,13 @@ private slots:
     void handleExpressionEdit(const QModelIndex& index);
     void requestDefaultExpression();
     void onDefaultExpressionBuilt(const QString& expression);
+    void updateDataPointLimitIndication();
 
 private:
     int selectedRowAfterDelete(int deletedStartIndex, int rowCnt);
     void initDefaultExpressionTarget(const QList<deviceId_t>& deviceIds);
+    void setupDataPointLimitIndication();
+    QString dataPointLimitWarningMessage() const;
     static bool sortRegistersLastFirst(const QModelIndex& s1, const QModelIndex& s2);
 
     Ui::RegisterDialog* _pUi;

--- a/src/dialogs/registerdialog.ui
+++ b/src/dialogs/registerdialog.ui
@@ -55,6 +55,19 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="dataPointLimitWarningLabel">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableView" name="registerView">
      <property name="minimumSize">
       <size>

--- a/src/models/adapterdata.cpp
+++ b/src/models/adapterdata.cpp
@@ -179,15 +179,39 @@ int AdapterData::maxDevicesFromSchema() const
 
 int AdapterData::maxDevicesFromCapabilities() const
 {
-    if (!_capabilities.contains("maxDevices"))
+    return capabilityLimit("maxDevices");
+}
+
+/*!
+ * \brief Return the maximum number of data points the adapter currently accepts per session.
+ * \return capabilities.maxRegisters, or INT_MAX when the adapter reports no such limit.
+ *
+ * The adapter only reports this capability while it enforces a cap (for example when no valid
+ * license is found); an absent key therefore means unlimited. The limit is enforced by the
+ * adapter itself when a session starts, so it is only used to inform the user.
+ */
+int AdapterData::maxRegisters() const
+{
+    return capabilityLimit("maxRegisters");
+}
+
+/*!
+ * \brief Return a max<Noun> limit from the capabilities object.
+ * \param key The capability key holding the limit.
+ * \return The reported limit, or INT_MAX when the key is absent or holds an invalid value.
+ *
+ * A negative or non-numeric limit is invalid capability data; it is treated as unbounded rather
+ * than risk truncating every configured item or warning the user about a limit that is not real.
+ */
+int AdapterData::capabilityLimit(const QString& key) const
+{
+    if (!_capabilities.contains(key))
     {
         return INT_MAX;
     }
 
-    /* A negative or non-numeric maxDevices is invalid capability data; treat it as unbounded
-     * rather than risk truncating every configured device. */
-    const int maxDevices = _capabilities.value("maxDevices").toInt(INT_MAX);
-    return maxDevices >= 0 ? maxDevices : INT_MAX;
+    const int limit = _capabilities.value(key).toInt(INT_MAX);
+    return limit >= 0 ? limit : INT_MAX;
 }
 
 int AdapterData::maxDevices() const

--- a/src/models/adapterdata.h
+++ b/src/models/adapterdata.h
@@ -97,6 +97,8 @@ public:
      */
     int maxDevicesFromCapabilities() const;
 
+    int maxRegisters() const;
+
     /*!
      * \brief Return the effective device limit currently in force for this adapter.
      * \return The smaller of maxDevicesFromSchema() and maxDevicesFromCapabilities(), since
@@ -116,6 +118,8 @@ public:
     QJsonObject configForWire() const;
 
 private:
+    int capabilityLimit(const QString& key) const;
+
     QString _name;
     QString _version;
     int _configVersion{ 0 };

--- a/tests/datahandling/CMakeLists.txt
+++ b/tests/datahandling/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_xtest(tst_datapointusage)
 add_xtest(tst_expressionparser)
 add_xtest(tst_graphdatahandler)
 add_xtest(tst_qmuparser)

--- a/tests/datahandling/tst_datapointusage.cpp
+++ b/tests/datahandling/tst_datapointusage.cpp
@@ -1,0 +1,115 @@
+#include "tst_datapointusage.h"
+
+#include "../communication/communicationhelpers.h"
+#include "../models/devicelisthelpers.h"
+#include "ProtocolAdapter/adapterhub.h"
+#include "datahandling/datapointusage.h"
+#include "models/graphdatamodel.h"
+#include "models/settingsmodel.h"
+
+#include <QTest>
+
+void TestDataPointUsage::init()
+{
+    _pSettingsModel = new SettingsModel;
+    _pGraphDataModel = new GraphDataModel(_pSettingsModel);
+}
+
+void TestDataPointUsage::cleanup()
+{
+    delete _pGraphDataModel;
+    delete _pSettingsModel;
+}
+
+void TestDataPointUsage::activeExpressionsSkipsInactive()
+{
+    auto exprList = QStringList() << "${40001}" << "${40002}" << "${40003}";
+    CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
+    _pGraphDataModel->setActive(GraphIdx(1), false);
+
+    auto expExpressions = QStringList() << "${40001}" << "${40003}";
+
+    QCOMPARE(DataPointUsage::activeExpressions(_pGraphDataModel), expExpressions);
+}
+
+void TestDataPointUsage::activeDataPointsSkipsInactive()
+{
+    auto exprList = QStringList() << "${40001}" << "${40002}";
+    CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
+    _pGraphDataModel->setActive(GraphIdx(1), false);
+
+    auto expDataPoints = QList<DataPoint>() << DataPoint("${40001}", Device::cFirstDeviceId);
+
+    QCOMPARE(DataPointUsage::activeDataPoints(_pGraphDataModel), expDataPoints);
+}
+
+/*!
+ * \brief A data point used by several signals is read once, so it is counted once.
+ */
+void TestDataPointUsage::activeDataPointsDedupesSharedDataPoint()
+{
+    auto exprList = QStringList() << "${40001}" << "${40001} + 1";
+    CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
+
+    auto expDataPoints = QList<DataPoint>() << DataPoint("${40001}", Device::cFirstDeviceId);
+
+    QCOMPARE(DataPointUsage::activeDataPoints(_pGraphDataModel), expDataPoints);
+}
+
+/*!
+ * \brief A single signal referencing several data points needs each of them read.
+ */
+void TestDataPointUsage::activeDataPointsCountsEveryReferenceInExpression()
+{
+    auto exprList = QStringList() << "${40001} + ${40002}";
+    CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
+
+    auto expDataPoints = QList<DataPoint>() << DataPoint("${40001}", Device::cFirstDeviceId)
+                                            << DataPoint("${40002}", Device::cFirstDeviceId);
+
+    QCOMPARE(DataPointUsage::activeDataPoints(_pGraphDataModel), expDataPoints);
+}
+
+void TestDataPointUsage::countPerAdapterEmptyWithoutDataPoints()
+{
+    QVERIFY(DataPointUsage::countPerAdapter(QList<DataPoint>(), _pSettingsModel).isEmpty());
+}
+
+void TestDataPointUsage::countPerAdapterCountsSingleAdapter()
+{
+    DeviceListHelpers::seedDevice(_pSettingsModel, Device::cFirstDeviceId, QString(cModbusAdapterId));
+
+    auto exprList = QStringList() << "${40001} + ${40002}" << "${40003}";
+    CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
+
+    const QMap<QString, int> counts =
+      DataPointUsage::countPerAdapter(DataPointUsage::activeDataPoints(_pGraphDataModel), _pSettingsModel);
+
+    QCOMPARE(counts.size(), 1);
+    QCOMPARE(counts.value(QString(cModbusAdapterId)), 3);
+}
+
+/*!
+ * \brief Every adapter enforces its own limit, so data points are counted per owning adapter.
+ */
+void TestDataPointUsage::countPerAdapterSplitsOverAdapters()
+{
+    const deviceId_t modbusDeviceId = Device::cFirstDeviceId;
+    const deviceId_t dummyDeviceId = Device::cFirstDeviceId + 1;
+    DeviceListHelpers::seedDevice(_pSettingsModel, modbusDeviceId, QString(cModbusAdapterId));
+    DeviceListHelpers::seedDevice(_pSettingsModel, dummyDeviceId, "dummy");
+
+    auto exprList = QStringList() << QString("${40001@%1}").arg(modbusDeviceId)
+                                  << QString("${40002@%1}").arg(dummyDeviceId)
+                                  << QString("${40003@%1}").arg(dummyDeviceId);
+    CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
+
+    const QMap<QString, int> counts =
+      DataPointUsage::countPerAdapter(DataPointUsage::activeDataPoints(_pGraphDataModel), _pSettingsModel);
+
+    QCOMPARE(counts.size(), 2);
+    QCOMPARE(counts.value(QString(cModbusAdapterId)), 1);
+    QCOMPARE(counts.value("dummy"), 2);
+}
+
+QTEST_GUILESS_MAIN(TestDataPointUsage)

--- a/tests/datahandling/tst_datapointusage.h
+++ b/tests/datahandling/tst_datapointusage.h
@@ -1,0 +1,34 @@
+
+#ifndef TEST_DATAPOINTUSAGE_H__
+#define TEST_DATAPOINTUSAGE_H__
+
+#include <QObject>
+
+/* Forward declaration */
+class GraphDataModel;
+class SettingsModel;
+
+class TestDataPointUsage : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    void activeExpressionsSkipsInactive();
+
+    void activeDataPointsSkipsInactive();
+    void activeDataPointsDedupesSharedDataPoint();
+    void activeDataPointsCountsEveryReferenceInExpression();
+
+    void countPerAdapterEmptyWithoutDataPoints();
+    void countPerAdapterCountsSingleAdapter();
+    void countPerAdapterSplitsOverAdapters();
+
+private:
+    SettingsModel* _pSettingsModel;
+    GraphDataModel* _pGraphDataModel;
+};
+
+#endif /* TEST_DATAPOINTUSAGE_H__ */

--- a/tests/dialogs/tst_registerdialog.cpp
+++ b/tests/dialogs/tst_registerdialog.cpp
@@ -7,6 +7,7 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QLabel>
 #include <QTest>
 
 /*!
@@ -152,6 +153,99 @@ void TestRegisterDialog::defaultRegisterRequestedAgainWhenSessionRestartsAfterAl
     _pMockAdapterManager->injectSessionStarted();
 
     QCOMPARE(_pMockAdapterManager->buildCalls.count(), 2);
+}
+
+/*!
+ * \brief Builds a describe response reporting a data point limit in its capabilities.
+ * \param maxRegisters The limit to report, or a negative value to leave the key out entirely
+ *        (which is how the adapter reports that it enforces no limit).
+ */
+QJsonObject TestRegisterDialog::buildDescribeWithMaxRegisters(int maxRegisters)
+{
+    QJsonObject capabilities;
+    if (maxRegisters >= 0)
+    {
+        capabilities["maxRegisters"] = maxRegisters;
+    }
+
+    QJsonObject describeResult;
+    describeResult["name"] = QStringLiteral("modbus");
+    describeResult["capabilities"] = capabilities;
+    return describeResult;
+}
+
+//! Add \a count active signals, each reading its own data point from the default device.
+void TestRegisterDialog::seedSignals(int count)
+{
+    for (int idx = 0; idx < count; idx++)
+    {
+        _pGraphDataModel->add();
+        _pGraphDataModel->setExpression(GraphIdx(_pGraphDataModel->size() - 1), QString("${%1}").arg(40001 + idx));
+    }
+}
+
+void TestRegisterDialog::dataPointLimitWarningHiddenWhenWithinLimit()
+{
+    DeviceListHelpers::seedDevice(&_settingsModel, 1, QStringLiteral("modbus"));
+    _settingsModel.updateAdapterFromDescribe(QStringLiteral("modbus"), buildDescribeWithMaxRegisters(5));
+    seedSignals(5);
+
+    _pDialog = new RegisterDialog(_pGraphDataModel, &_settingsModel, _pMockHub);
+
+    auto* warningLabel = _pDialog->findChild<QLabel*>("dataPointLimitWarningLabel");
+    QVERIFY(warningLabel != nullptr);
+    QVERIFY(warningLabel->isHidden());
+}
+
+void TestRegisterDialog::dataPointLimitWarningShownWhenExceeded()
+{
+    DeviceListHelpers::seedDevice(&_settingsModel, 1, QStringLiteral("modbus"));
+    _settingsModel.updateAdapterFromDescribe(QStringLiteral("modbus"), buildDescribeWithMaxRegisters(5));
+    seedSignals(6);
+
+    _pDialog = new RegisterDialog(_pGraphDataModel, &_settingsModel, _pMockHub);
+
+    auto* warningLabel = _pDialog->findChild<QLabel*>("dataPointLimitWarningLabel");
+    QVERIFY(warningLabel != nullptr);
+    QVERIFY(!warningLabel->isHidden());
+    QVERIFY(warningLabel->text().contains("modbus"));
+    QVERIFY(warningLabel->text().contains("5"));
+    QVERIFY(warningLabel->text().contains("6"));
+}
+
+/*!
+ * \brief Deactivating a signal drops its data point from the session, so the warning must
+ * disappear again while the dialog stays open.
+ */
+void TestRegisterDialog::dataPointLimitWarningHiddenWhenSignalDeactivated()
+{
+    DeviceListHelpers::seedDevice(&_settingsModel, 1, QStringLiteral("modbus"));
+    _settingsModel.updateAdapterFromDescribe(QStringLiteral("modbus"), buildDescribeWithMaxRegisters(5));
+    seedSignals(6);
+
+    _pDialog = new RegisterDialog(_pGraphDataModel, &_settingsModel, _pMockHub);
+
+    auto* warningLabel = _pDialog->findChild<QLabel*>("dataPointLimitWarningLabel");
+    QVERIFY(warningLabel != nullptr);
+    QVERIFY(!warningLabel->isHidden());
+
+    _pGraphDataModel->setActive(GraphIdx(0), false);
+
+    QVERIFY(warningLabel->isHidden());
+}
+
+//! A licensed adapter reports no maxRegisters at all, so no number of signals may warn.
+void TestRegisterDialog::dataPointLimitWarningHiddenWhenAdapterReportsNoLimit()
+{
+    DeviceListHelpers::seedDevice(&_settingsModel, 1, QStringLiteral("modbus"));
+    _settingsModel.updateAdapterFromDescribe(QStringLiteral("modbus"), buildDescribeWithMaxRegisters(-1));
+    seedSignals(20);
+
+    _pDialog = new RegisterDialog(_pGraphDataModel, &_settingsModel, _pMockHub);
+
+    auto* warningLabel = _pDialog->findChild<QLabel*>("dataPointLimitWarningLabel");
+    QVERIFY(warningLabel != nullptr);
+    QVERIFY(warningLabel->isHidden());
 }
 
 QTEST_MAIN(TestRegisterDialog)

--- a/tests/dialogs/tst_registerdialog.h
+++ b/tests/dialogs/tst_registerdialog.h
@@ -79,8 +79,15 @@ private slots:
     void defaultRegisterRequestedImmediatelyWhenAdapterAlreadyReady();
     void defaultRegisterRequestedAgainWhenSessionRestartsAfterAlreadyActive();
 
+    void dataPointLimitWarningHiddenWhenWithinLimit();
+    void dataPointLimitWarningShownWhenExceeded();
+    void dataPointLimitWarningHiddenWhenSignalDeactivated();
+    void dataPointLimitWarningHiddenWhenAdapterReportsNoLimit();
+
 private:
     static QJsonObject buildTestRegisterSchema();
+    static QJsonObject buildDescribeWithMaxRegisters(int maxRegisters);
+    void seedSignals(int count);
 
     SettingsModel _settingsModel;
     GraphDataModel* _pGraphDataModel{ nullptr };

--- a/tests/models/tst_adapterdata.cpp
+++ b/tests/models/tst_adapterdata.cpp
@@ -461,6 +461,74 @@ void TestAdapterData::maxDevicesReturnsSmallerOfSchemaAndCapabilities()
 }
 
 /*!
+ * \brief maxRegisters returns INT_MAX when capabilities has no maxRegisters, which is how a
+ * licensed adapter reports that it enforces no data point limit at all.
+ */
+void TestAdapterData::maxRegistersReturnsIntMaxWhenAbsent()
+{
+    AdapterData data;
+
+    QJsonObject describeResult;
+    describeResult["capabilities"] = QJsonObject();
+    data.updateFromDescribe(describeResult);
+
+    QCOMPARE(data.maxRegisters(), INT_MAX);
+}
+
+/*!
+ * \brief maxRegisters returns the maxRegisters value from capabilities.
+ */
+void TestAdapterData::maxRegistersReturnsValue()
+{
+    AdapterData data;
+
+    QJsonObject caps;
+    caps["maxRegisters"] = 5;
+
+    QJsonObject describeResult;
+    describeResult["capabilities"] = caps;
+    data.updateFromDescribe(describeResult);
+
+    QCOMPARE(data.maxRegisters(), 5);
+}
+
+/*!
+ * \brief maxRegisters returns INT_MAX when maxRegisters is negative, since a negative limit is
+ * invalid capability data rather than a real cap.
+ */
+void TestAdapterData::maxRegistersReturnsIntMaxWhenNegative()
+{
+    AdapterData data;
+
+    QJsonObject caps;
+    caps["maxRegisters"] = -1;
+
+    QJsonObject describeResult;
+    describeResult["capabilities"] = caps;
+    data.updateFromDescribe(describeResult);
+
+    QCOMPARE(data.maxRegisters(), INT_MAX);
+}
+
+/*!
+ * \brief maxRegisters returns 0 when maxRegisters is explicitly 0, since that is a legitimate
+ * limit ("no data points allowed") rather than invalid capability data.
+ */
+void TestAdapterData::maxRegistersReturnsZeroWhenExplicit()
+{
+    AdapterData data;
+
+    QJsonObject caps;
+    caps["maxRegisters"] = 0;
+
+    QJsonObject describeResult;
+    describeResult["capabilities"] = caps;
+    data.updateFromDescribe(describeResult);
+
+    QCOMPARE(data.maxRegisters(), 0);
+}
+
+/*!
  * \brief configForWire caps the "devices" array to maxDevicesFromSchema(), unlike
  * effectiveConfig() which returns every stored device.
  */

--- a/tests/models/tst_adapterdata.h
+++ b/tests/models/tst_adapterdata.h
@@ -41,6 +41,11 @@ private slots:
 
     void maxDevicesReturnsSmallerOfSchemaAndCapabilities();
 
+    void maxRegistersReturnsIntMaxWhenAbsent();
+    void maxRegistersReturnsValue();
+    void maxRegistersReturnsIntMaxWhenNegative();
+    void maxRegistersReturnsZeroWhenExplicit();
+
     void configForWireCapsDevicesToMaxItems();
     void configForWireReturnsAllDevicesWhenNoLimit();
     void configForWireDoesNotTruncateWhenMaxItemsNegative();


### PR DESCRIPTION
The adapter reports capabilities.maxRegisters while it enforces a data
point cap, for example when no valid license is found. Show a warning in
the signals dialog when the active signals need more data points than the
adapter allows, mirroring the device limit warning in the device settings.

Logging is not blocked: the adapter reports the limit itself when a
session starts.

Add DataPointUsage to collect the deduplicated data points of the active
signals and count them per adapter, the same list and grouping used when
logging starts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P5cWu3NCXnaSXGqoQLxfQK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning in the Register dialog when active data points exceed an adapter’s session limit.
  - Warning details include the affected adapter and current versus permitted data-point counts.
  - Warnings update as signals are activated or deactivated.
  - Added support for reading adapter data-point limits, including unlimited and explicitly zero limits.

- **Bug Fixes**
  - Active data-point usage is now consistently identified and counted across signals and adapters.

- **Tests**
  - Added coverage for data-point tracking, adapter limits, and warning visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->